### PR TITLE
Фолбэк при недоступности Telegram: сервер больше не падает

### DIFF
--- a/packages/backend/src/app/chat/chat.service.ts
+++ b/packages/backend/src/app/chat/chat.service.ts
@@ -84,7 +84,7 @@ export class ChatService {
 
     const tgMessage = await this.telegramService.sendMessage(tgText, car.owner);
 
-    if (coords) {
+    if (tgMessage && coords) {
       await this.telegramService.sendLocation(coords, car.owner, {
         reply_to_message_id: tgMessage.message_id,
       });
@@ -120,7 +120,7 @@ export class ChatService {
           }
         : undefined,
       userId,
-      telegramId: tgMessage.message_id.toString(),
+      telegramId: tgMessage?.message_id.toString() ?? null,
     });
   }
 
@@ -167,7 +167,7 @@ export class ChatService {
           }
         : undefined,
       userId,
-      telegramId: tgMessage.message_id.toString(),
+      telegramId: tgMessage?.message_id.toString() ?? null,
     });
 
     if (newAnonymousId) {

--- a/packages/backend/src/app/telegram/telegram.module.ts
+++ b/packages/backend/src/app/telegram/telegram.module.ts
@@ -27,6 +27,7 @@ import { User } from '../entities/user/user.entity';
             useFactory: (configService: ConfigService) => ({
               token: configService.telegram.token,
               middlewares: [session()],
+              launchOptions: false,
             }),
           }),
         ]),

--- a/packages/backend/src/app/telegram/telegram.service.ts
+++ b/packages/backend/src/app/telegram/telegram.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectBot, On } from 'nestjs-telegraf';
 import { Telegraf } from 'telegraf';
 import { User } from '../entities/user/user.entity';
@@ -8,11 +8,22 @@ import { Buffer } from 'buffer';
 import { RequestUser } from '@paulislava/shared/user/user.types';
 
 @Injectable()
-export class TelegramService {
-  constructor(@InjectBot() private readonly bot: Telegraf) {}
-  // private readonly bot: Telegraf;
+export class TelegramService implements OnModuleInit {
+  private readonly logger = new Logger(TelegramService.name);
+  private available = false;
 
-  // constructor() {}
+  constructor(@InjectBot() private readonly bot: Telegraf) {}
+
+  async onModuleInit() {
+    try {
+      await this.bot.launch();
+      this.available = true;
+      this.logger.log('Telegram bot launched successfully');
+    } catch (error) {
+      this.available = false;
+      this.logger.error('Telegram bot failed to launch, running without Telegram', error);
+    }
+  }
 
   @On('text')
   async handleMessage() {
@@ -24,10 +35,19 @@ export class TelegramService {
     recipient: User,
     replyToMessageId?: number,
   ) {
-    return this.bot.telegram.sendMessage(recipient.telegramID, message, {
-      parse_mode: 'HTML',
-      reply_to_message_id: replyToMessageId,
-    });
+    if (!this.available) {
+      this.logger.warn(`Telegram unavailable, skipping sendMessage to ${recipient.telegramID}`);
+      return null;
+    }
+    try {
+      return await this.bot.telegram.sendMessage(recipient.telegramID, message, {
+        parse_mode: 'HTML',
+        reply_to_message_id: replyToMessageId,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to send Telegram message to ${recipient.telegramID}`, error);
+      return null;
+    }
   }
 
   async sendLocation(
@@ -35,12 +55,21 @@ export class TelegramService {
     recipient: User,
     extra?: ExtraLocation,
   ) {
-    return this.bot.telegram.sendLocation(
-      recipient.telegramID,
-      latitude,
-      longitude,
-      extra,
-    );
+    if (!this.available) {
+      this.logger.warn(`Telegram unavailable, skipping sendLocation to ${recipient.telegramID}`);
+      return null;
+    }
+    try {
+      return await this.bot.telegram.sendLocation(
+        recipient.telegramID,
+        latitude,
+        longitude,
+        extra,
+      );
+    } catch (error) {
+      this.logger.error(`Failed to send Telegram location to ${recipient.telegramID}`, error);
+      return null;
+    }
   }
 
   async sendPhoto(
@@ -49,19 +78,28 @@ export class TelegramService {
     filename: string,
     caption?: string,
   ) {
+    if (!this.available) {
+      this.logger.warn(`Telegram unavailable, skipping sendPhoto to ${recipient.telegramID}`);
+      return null;
+    }
     const buffer = Buffer.from(
       base64Image.replace(/^data:image\/\w+;base64,/, ''),
       'base64',
     );
-    return this.bot.telegram.sendDocument(
-      recipient.telegramID,
-      {
-        source: buffer,
-        filename: filename,
-      },
-      {
-        caption,
-      },
-    );
+    try {
+      return await this.bot.telegram.sendDocument(
+        recipient.telegramID,
+        {
+          source: buffer,
+          filename: filename,
+        },
+        {
+          caption,
+        },
+      );
+    } catch (error) {
+      this.logger.error(`Failed to send Telegram photo to ${recipient.telegramID}`, error);
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Что изменилось

Сервер падал при недоступности Telegram API. Причина: `nestjs-telegraf` вызывал `bot.launch()` без `await` (fire-and-forget), что приводило к unhandled promise rejection — в Node.js 15+ это крашит процесс.

## Изменения

### `telegram.module.ts`
Добавлен `launchOptions: false` — отключает авто-запуск бота внутри `nestjs-telegraf`. Теперь запуском управляет сам `TelegramService`.

### `telegram.service.ts`
- Реализует `OnModuleInit`: запускает бота вручную с `try/catch`, устанавливает флаг `available`
- Все методы (`sendMessage`, `sendLocation`, `sendPhoto`) проверяют флаг и оборачивают вызовы Telegram API в `try/catch`, возвращая `null` вместо броска исключения
- При недоступности — предупреждение в логах, сервер продолжает работу

### `chat.service.ts`
- Обрабатывает `null` от `sendTelegramMessage`
- Сообщение от пользователя сохраняется в БД с `telegramId: null`
- Локация отправляется только если основное сообщение прошло успешно
- Ответ клиенту отправляется штатно вне зависимости от Telegram

## Поведение при недоступности Telegram
- Сервер стартует без падений
- Входящие сообщения сохраняются в БД
- В логах появляются `WARN`/`ERROR` с причиной
- Функциональность, не связанная с Telegram, не затрагивается