### PR TITLE
Fix prettier errors in usePushNotifications (CI fix)

### DIFF
--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -7,7 +7,7 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = atob(base64);
-  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+  return Uint8Array.from([...rawData].map(c => c.charCodeAt(0)));
 }
 
 export function usePushNotifications() {
@@ -30,7 +30,7 @@ export function usePushNotifications() {
         existing ??
         (await registration.pushManager.subscribe({
           userVisibleOnly: true,
-          applicationServerKey,
+          applicationServerKey
         }));
 
       const { endpoint, keys } = subscription.toJSON() as {


### PR DESCRIPTION
Fixes the `build-web` CI failure caused by two prettier errors in `usePushNotifications.ts`:

- Arrow function parameter `(c)` → `c` (no parens for single arg)
- Remove trailing comma in object literal

https://claude.ai/code/session_014oYBXcwSG9PFMVxT6B4zMA

---
_Generated by [Claude Code](https://claude.ai/code/session_014oYBXcwSG9PFMVxT6B4zMA)_