### PR TITLE
feat: request notification permission once per session

### DIFF
--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -3,6 +3,8 @@
 import { useEffect } from 'react';
 import { notificationService } from '@/services';
 
+const PUSH_SESSION_KEY = 'push_notifications_init';
+
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
@@ -14,8 +16,11 @@ export function usePushNotifications() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    if (sessionStorage.getItem(PUSH_SESSION_KEY)) return;
 
     async function init() {
+      sessionStorage.setItem(PUSH_SESSION_KEY, '1');
+
       const permission = await Notification.requestPermission();
       if (permission !== 'granted') return;
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added `sessionStorage` guard (`push_notifications_init`) to `usePushNotifications` so the browser notification permission dialog is shown at most once per browser session per authenticated user
- The flag is set before calling `requestPermission()` to prevent duplicate calls even if the async flow is interrupted
- Existing wiring (`NotificationsInit` → `PushNotificationsSubscriber` → `usePushNotifications`) is unchanged; only the per-session deduplication was missing

## Test plan

- [ ] Log in as an authenticated user — notification permission dialog appears on first page load of the session
- [ ] Navigate to other pages within the same tab — dialog does not appear again
- [ ] Open a new tab and log in — dialog appears again (new sessionStorage scope)
- [ ] Grant permission → push subscription is registered with the backend
- [ ] Deny permission → no subscription attempt, no error

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_