### PR TITLE
fix: show notification permission banner on user gesture (iOS fix)

### DIFF
--- a/packages/web/src/components/NotificationsInit/notification-banner.tsx
+++ b/packages/web/src/components/NotificationsInit/notification-banner.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React from 'react';
+import styled from 'styled-components';
+import { Button } from '@/ui/Button';
+import { themeable } from '@/themes/utils';
+
+interface NotificationBannerProps {
+  onEnable(): Promise<void>;
+  onDismiss(): void;
+}
+
+const Banner = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  padding-bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  background: ${themeable('mainBackgroundColor')};
+  border-top: 1px solid ${themeable('secondaryBackground')};
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+`;
+
+const Text = styled.span`
+  flex: 1;
+  font-size: 14px;
+  color: ${themeable('textColor')};
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  font-size: 20px;
+  line-height: 1;
+  color: ${themeable('textColor')};
+  opacity: 0.5;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export function NotificationBanner({ onEnable, onDismiss }: NotificationBannerProps) {
+  return (
+    <Banner>
+      <Text>Включить уведомления о сообщениях?</Text>
+      <Button size='sm' onClick={onEnable}>
+        Включить
+      </Button>
+      <CloseButton onClick={onDismiss} aria-label='Закрыть'>
+        ✕
+      </CloseButton>
+    </Banner>
+  );
+}

--- a/packages/web/src/components/NotificationsInit/notifications-init.tsx
+++ b/packages/web/src/components/NotificationsInit/notifications-init.tsx
@@ -3,10 +3,14 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/context/Auth/Auth.context';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
+import { NotificationBanner } from './notification-banner';
 
 function PushNotificationsSubscriber() {
-  usePushNotifications();
-  return null;
+  const { showBanner, onEnable, onDismiss } = usePushNotifications();
+
+  if (!showBanner) return null;
+
+  return <NotificationBanner onEnable={onEnable} onDismiss={onDismiss} />;
 }
 
 export function NotificationsInit() {

--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { notificationService } from '@/services';
 
 const PUSH_SESSION_KEY = 'push_notifications_init';
@@ -12,40 +12,65 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   return Uint8Array.from([...rawData].map(c => c.charCodeAt(0)));
 }
 
+async function subscribeAfterPermission() {
+  const registration = await navigator.serviceWorker.register('/service-worker.js');
+  await navigator.serviceWorker.ready;
+
+  const { publicKey } = await notificationService.vapidPublicKey();
+  const applicationServerKey = urlBase64ToUint8Array(publicKey);
+
+  const existing = await registration.pushManager.getSubscription();
+  const subscription =
+    existing ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey
+    }));
+
+  const { endpoint, keys } = subscription.toJSON() as {
+    endpoint: string;
+    keys: { p256dh: string; auth: string };
+  };
+
+  await notificationService.subscribe({ endpoint, keys });
+}
+
 export function usePushNotifications() {
+  const [showBanner, setShowBanner] = useState(false);
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) return;
     if (sessionStorage.getItem(PUSH_SESSION_KEY)) return;
 
-    async function init() {
+    if (Notification.permission === 'granted') {
       sessionStorage.setItem(PUSH_SESSION_KEY, '1');
-
-      const permission = await Notification.requestPermission();
-      if (permission !== 'granted') return;
-
-      const registration = await navigator.serviceWorker.register('/service-worker.js');
-      await navigator.serviceWorker.ready;
-
-      const { publicKey } = await notificationService.vapidPublicKey();
-      const applicationServerKey = urlBase64ToUint8Array(publicKey);
-
-      const existing = await registration.pushManager.getSubscription();
-      const subscription =
-        existing ??
-        (await registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey
-        }));
-
-      const { endpoint, keys } = subscription.toJSON() as {
-        endpoint: string;
-        keys: { p256dh: string; auth: string };
-      };
-
-      await notificationService.subscribe({ endpoint, keys });
+      subscribeAfterPermission().catch(() => {});
+      return;
     }
 
-    init().catch(() => {});
+    if (Notification.permission === 'denied') {
+      sessionStorage.setItem(PUSH_SESSION_KEY, '1');
+      return;
+    }
+
+    setShowBanner(true);
   }, []);
+
+  const onEnable = useCallback(async () => {
+    sessionStorage.setItem(PUSH_SESSION_KEY, '1');
+    setShowBanner(false);
+
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return;
+
+    await subscribeAfterPermission();
+  }, []);
+
+  const onDismiss = useCallback(() => {
+    sessionStorage.setItem(PUSH_SESSION_KEY, '1');
+    setShowBanner(false);
+  }, []);
+
+  return { showBanner, onEnable, onDismiss };
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- На iOS Safari/PWA `Notification.requestPermission()` молча игнорируется без жеста пользователя — автозапрос из `useEffect` никогда не показывал диалог
- Добавлен баннер снизу экрана «Включить уведомления о сообщениях?» с кнопками «Включить» и ✕
- `requestPermission()` теперь вызывается только по клику — что корректно работает на iOS
- Добавлена проверка `!('Notification' in window)` для защиты от TypeError на старых/ограниченных платформах
- Уже выданные разрешения (`granted`) обрабатываются тихо без баннера

## Test plan

- [ ] Desktop Chrome/Firefox: баннер появляется при первом посещении, «Включить» показывает системный диалог
- [ ] iOS Safari PWA (добавлено на домашний экран): баннер появляется, по нажатию «Включить» появляется системный диалог iOS
- [ ] Кнопка ✕ скрывает баннер и не показывает его повторно в той же сессии
- [ ] Повторный вход в сессию после grant: баннер не показывается, подписка тихо обновляется

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_