### PR TITLE
ci: separate build/deploy stages, GitHub runners + SSH deploy

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,6 +74,7 @@ jobs:
   deploy-backend:
     runs-on: ubuntu-latest
     needs: build-backend
+    if: github.event_name == 'push'
     steps:
       - name: Deploy backend
         uses: appleboy/ssh-action@v1.2.0
@@ -122,6 +124,7 @@ jobs:
     needs:
       - build-web
       - deploy-backend
+    if: github.event_name == 'push'
     steps:
       - name: Deploy web
         uses: appleboy/ssh-action@v1.2.0
@@ -169,7 +172,7 @@ jobs:
     needs:
       - deploy-backend
       - deploy-web
-    if: always()
+    if: always() && github.event_name == 'push'
     steps:
       - name: Clean up server
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,66 +5,179 @@ on:
     branches:
       - master
 
-# Добавляем конфигурацию concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-backend:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Build backend Docker image
-        run: |
-          echo "Building backend Docker image..."
-          docker build --target backend --rm -t beznomera:backend https://github.com/paulislava/beznomera.git
-          docker stop beznomera_backend || true
-          docker rm -f beznomera_backend || true
+      - uses: actions/checkout@v4
 
-          docker run --name beznomera_backend -d -it --network host --env-file /home/user/web/beznomera.net/web.env -v /home/user/web/beznomera.net/config-backend.yaml:/config.yaml -v /home/user/web/beznomera.net/ip-location-data:/app/node_modules/ip-location-api/data beznomera:backend
-          docker rmi $(docker images --filter "dangling=true" -q --no-trunc beznomera_backend) || true
+      - uses: docker/setup-buildx-action@v3
 
-  # build-frontend:
-  #   runs-on: self-hosted
-  #   steps:
-  #     - name: Build frontend Docker image
-  #       run: |
-  #         echo "Building frontend Docker image..."
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #         # Собираем образ с переменными окружения
-  #         docker build --rm -f frontend.Dockerfile -t beznomera:frontend https://github.com/paulislava/beznomera.git
-          
-  #         docker stop beznomera_frontend || true
-  #         docker rm -f beznomera_frontend || true
-
-  #         docker run --name beznomera_frontend -it -d -p 3001:80 -v /home/user/web/beznomera.net/frontend.env:/.env beznomera:frontend
-  #         docker rmi $(docker images --filter "dangling=true" -q --no-trunc beznomera_frontend) || true
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: backend
+          push: true
+          tags: |
+            ghcr.io/paulislava/beznomera:backend-${{ github.sha }}
+            ghcr.io/paulislava/beznomera:backend-latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
 
   build-web:
-    runs-on: self-hosted
-    needs:
-      - build-backend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Build web Docker image
-        run: |
-          echo "Building web Docker image..."
-          docker build --target web --rm -f web.Dockerfile -t beznomera:web --build-arg BACKEND_API_TOKEN=${{ secrets.BACKEND_API_TOKEN }} https://github.com/paulislava/beznomera.git
-          docker stop beznomera_web || true
-          docker rm -f beznomera_web || true
+      - uses: actions/checkout@v4
 
-          docker run --name beznomera_web -d -it -p 4000:3000 --env-file /home/user/web/beznomera.net/web.env beznomera:web
-          docker rmi $(docker images --filter "dangling=true" -q --no-trunc beznomera_web) || true
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: web.Dockerfile
+          target: web
+          push: true
+          tags: |
+            ghcr.io/paulislava/beznomera:web-${{ github.sha }}
+            ghcr.io/paulislava/beznomera:web-latest
+          build-args: |
+            BACKEND_API_TOKEN=${{ secrets.BACKEND_API_TOKEN }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+  deploy-backend:
+    runs-on: ubuntu-latest
+    needs: build-backend
+    steps:
+      - name: Deploy backend
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_ACTOR: ${{ github.actor }}
+          IMAGE_TAG: ${{ github.sha }}
+        with:
+          host: beznomera.net
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          envs: GHCR_TOKEN,GHCR_ACTOR,IMAGE_TAG
+          script: |
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+            docker pull ghcr.io/paulislava/beznomera:backend-$IMAGE_TAG
+            docker stop beznomera_backend || true
+            docker rm -f beznomera_backend || true
+            docker run --name beznomera_backend -d --network host \
+              --env-file /home/user/web/beznomera.net/web.env \
+              -v /home/user/web/beznomera.net/config-backend.yaml:/config.yaml \
+              -v /home/user/web/beznomera.net/ip-location-data:/app/node_modules/ip-location-api/data \
+              ghcr.io/paulislava/beznomera:backend-$IMAGE_TAG
+
+      - name: Health check backend
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: beznomera.net
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          script: |
+            for i in $(seq 1 10); do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:4444/ 2>/dev/null || echo "000")
+              if [ "$STATUS" != "000" ]; then
+                echo "Backend healthy (HTTP $STATUS) on attempt $i"
+                exit 0
+              fi
+              echo "Attempt $i/10: backend not ready, waiting 30s..."
+              sleep 30
+            done
+            echo "Backend failed health check after 10 attempts"
+            exit 1
+
+  deploy-web:
+    runs-on: ubuntu-latest
+    needs:
+      - build-web
+      - deploy-backend
+    steps:
+      - name: Deploy web
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_ACTOR: ${{ github.actor }}
+          IMAGE_TAG: ${{ github.sha }}
+        with:
+          host: beznomera.net
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          envs: GHCR_TOKEN,GHCR_ACTOR,IMAGE_TAG
+          script: |
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+            docker pull ghcr.io/paulislava/beznomera:web-$IMAGE_TAG
+            docker stop beznomera_web || true
+            docker rm -f beznomera_web || true
+            docker run --name beznomera_web -d -p 4000:3000 \
+              --env-file /home/user/web/beznomera.net/web.env \
+              ghcr.io/paulislava/beznomera:web-$IMAGE_TAG
+
+      - name: Health check web
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: beznomera.net
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          script: |
+            for i in $(seq 1 10); do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:4000/ 2>/dev/null || echo "000")
+              if [ "$STATUS" != "000" ]; then
+                echo "Web healthy (HTTP $STATUS) on attempt $i"
+                exit 0
+              fi
+              echo "Attempt $i/10: web not ready, waiting 30s..."
+              sleep 30
+            done
+            echo "Web failed health check after 10 attempts"
+            exit 1
 
   clean:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs:
-      # - build-frontend
-      - build-backend
-      - build-web
+      - deploy-backend
+      - deploy-web
     if: always()
     steps:
-      - name: Clean unused containers and volumes
-        run: |
-          echo "Deleting unused containers, volumes..."
-          docker system prune -f
-
+      - name: Clean up server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: beznomera.net
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          script: |
+            docker image prune -f
+            docker container prune -f

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -18,8 +18,10 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/platform-socket.io": "^10.0.0",
         "@nestjs/schedule": "^5.0.1",
         "@nestjs/typeorm": "^10.0.2",
+        "@nestjs/websockets": "^10.0.0",
         "@paulislava/shared": "file:../shared",
         "@types/web-push": "3.6.4",
         "bcrypt": "^5.1.1",
@@ -2884,6 +2886,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.4.22.tgz",
+      "integrity": "sha512-xxGw3R0Ihr51/Omq23z3//bKmCXyVKaikxbH0/pkwqMsQrxkUv9NabNUZ22b4Jnlwwi02X+zlwo8GRa9u8oV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@nestjs/schedule": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
@@ -2959,6 +2986,35 @@
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
       }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
+      "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/platform-socket.io": "^10.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/websockets/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3742,6 +3798,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -3862,6 +3924,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ejs": {
       "version": "3.1.5",
@@ -4115,6 +4186,15 @@
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
       "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5088,6 +5168,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
@@ -6615,6 +6704,59 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
+      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
@@ -11056,6 +11198,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -12765,6 +12916,116 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.7.4",
@@ -14498,6 +14759,27 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -16721,6 +17003,22 @@
         }
       }
     },
+    "@nestjs/platform-socket.io": {
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.4.22.tgz",
+      "integrity": "sha512-xxGw3R0Ihr51/Omq23z3//bKmCXyVKaikxbH0/pkwqMsQrxkUv9NabNUZ22b4Jnlwwi02X+zlwo8GRa9u8oV9g==",
+      "requires": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "@nestjs/schedule": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
@@ -16765,6 +17063,23 @@
       "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
       "requires": {
         "uuid": "9.0.1"
+      }
+    },
+    "@nestjs/websockets": {
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
+      "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
+      "requires": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -17374,6 +17689,11 @@
         "tslib": "^2.6.2"
       }
     },
+    "@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -17494,6 +17814,14 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/ejs": {
       "version": "3.1.5",
@@ -17747,6 +18075,14 @@
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
       "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "requires": {
         "@types/node": "*"
       }
@@ -18473,6 +18809,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "bcrypt": {
       "version": "5.1.1",
@@ -19582,6 +19923,43 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.0.0.tgz",
       "integrity": "sha512-++P0RhebUC8MJAwJOsT93dT+5oc5oPImp1HubZpAuCZ5kTLnhuuBhKHj2jJeO/Gj93idPBWmIuQ9QWMe5rX3pQ=="
+    },
+    "engine.io": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
+      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
+      "requires": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
     },
     "enhanced-resolve": {
       "version": "5.15.0",
@@ -22991,6 +23369,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+    },
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -24255,6 +24638,83 @@
       "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
       "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A=="
     },
+    "socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "requires": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -25413,6 +25873,11 @@
           "dev": true
         }
       }
+    },
+    "ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/packages/backend/src/app/chat/chat.service.ts
+++ b/packages/backend/src/app/chat/chat.service.ts
@@ -52,7 +52,7 @@ export class ChatService {
 
   private mapChatToInfo(chat: Chat, messages: ChatMessage[]): ChatInfo {
     const senderName =
-      chat.sender?.name ??
+      chat.sender?.firstName ??
       chat.anonymousSender?.id?.slice(0, 8) ??
       'Анонимный';
 
@@ -79,7 +79,7 @@ export class ChatService {
 
   private mapChatToDetails(chat: Chat): ChatDetails {
     const senderName =
-      chat.sender?.name ??
+      chat.sender?.firstName ??
       chat.anonymousSender?.id?.slice(0, 8) ??
       'Анонимный';
 

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -67,6 +67,31 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -78,6 +103,14 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/telegram-login-button": {
       "version": "0.1.0",
@@ -142,6 +175,23 @@
         "react-is": "^16.13.1"
       }
     },
+    "react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "peer": true
+    },
+    "react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "scheduler": "^0.27.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -153,6 +203,13 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "peer": true
     },
     "telegram-login-button": {
       "version": "0.1.0",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@chatscope/chat-ui-kit-react": "^2.0.3",
+        "@chatscope/chat-ui-kit-styles": "^1.4.0",
         "@heroui/react": "2.8.1",
         "@telegram-apps/sdk-react": "^3.3.6",
         "@types/jsonwebtoken": "9.0.10",
@@ -22,6 +24,7 @@
         "react-imask": "^7.6.1",
         "react-qrcode-logo": "4.0.0",
         "react-textarea-autosize": "^8.5.9",
+        "socket.io-client": "^4.8.1",
         "styled-components": "^6.1.18",
         "telegram-login-button": "^0.1.0"
       },
@@ -1844,6 +1847,32 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@chatscope/chat-ui-kit-react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chatscope/chat-ui-kit-react/-/chat-ui-kit-react-2.1.1.tgz",
+      "integrity": "sha512-rCtE9abdmAbBDkAAUYBC1TDTBMZHquqFIZhADptAfHcJ8z8W3XH/z/ZuwBSJXtzi6h1mwCNc3tBmm1A2NLGhNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chatscope/chat-ui-kit-styles": "^1.2.0",
+        "@fortawesome/fontawesome-free": "^6.5.2",
+        "@fortawesome/fontawesome-svg-core": "^6.5.2",
+        "@fortawesome/free-solid-svg-icons": "^6.5.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.12.0 || ^17.0.0 || ^18.2.0 || ^19.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@chatscope/chat-ui-kit-styles": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@chatscope/chat-ui-kit-styles/-/chat-ui-kit-styles-1.4.0.tgz",
+      "integrity": "sha512-016mBJD3DESw7Nh+lkKcPd22xG92ghA0VpIXIbjQtmXhC7Ve6wRazTy8z1Ahut+Tbv179+JxrftuMngsj/yV8Q==",
+      "license": "MIT"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -2082,6 +2111,62 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.6.tgz",
+      "integrity": "sha512-mtBFIi1UsYQo7rYonYFkjgYKGoL8T+fEH6NGUpvuqtY3ytMsAoDaPo5rk25KuMtKDipY4bGYM/CkmCHA1N3FUg==",
+      "deprecated": "v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@heroui/accordion": {
@@ -5877,6 +5962,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@storybook/components": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.14.tgz",
@@ -7788,6 +7879,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -8196,7 +8293,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8458,6 +8554,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -13184,6 +13302,34 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -14651,6 +14797,35 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,7 @@
     "telegram-login-button": "^0.1.0",
     "socket.io-client": "^4.8.1",
     "@chatscope/chat-ui-kit-react": "^2.0.3",
-    "@chatscope/chat-ui-kit-styles": "^1.4.2"
+    "@chatscope/chat-ui-kit-styles": "^1.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/packages/web/src/components/CarInfo/CarChatPage.tsx
+++ b/packages/web/src/components/CarInfo/CarChatPage.tsx
@@ -32,9 +32,7 @@ export const CarChatPage: React.FC<CarInfoProps> = ({ info, code }) => {
       .finally(() => setLoading(false));
   }, [code]);
 
-  const title = [info.no, info.brandRaw ?? info.brand?.title, info.model]
-    .filter(Boolean)
-    .join(' ');
+  const title = [info.no, info.brandRaw ?? info.brand?.title, info.model].filter(Boolean).join(' ');
 
   if (loading) return null;
 
@@ -46,7 +44,10 @@ export const CarChatPage: React.FC<CarInfoProps> = ({ info, code }) => {
           chatId={chat.id}
           initialMessages={chat.messages}
           isOwner={false}
-          initialContact={{ contactType: chat.contactType ?? undefined, contactValue: chat.contactValue ?? undefined }}
+          initialContact={{
+            contactType: chat.contactType ?? undefined,
+            contactValue: chat.contactValue ?? undefined
+          }}
         />
       ) : (
         <div style={{ padding: 20 }}>Не удалось загрузить чат</div>

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -5,9 +5,9 @@ import {
   Conversation,
   ConversationList,
   MainContainer,
-  Sidebar,
+  Sidebar
 } from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/cjs/styles.min.css';
+import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
 import styled from 'styled-components';
 
 import { ChatInfo, ChatMessageInfo } from '@shared/chat/chat.types';
@@ -36,7 +36,8 @@ const Wrapper = styled.div`
     background: ${themeable('secondaryBackground')};
     color: ${themeable('textColor')};
 
-    &:hover, &[data-active='true'] {
+    &:hover,
+    &[data-active='true'] {
       background: ${themeable('mainBackgroundColor')};
     }
   }
@@ -80,20 +81,16 @@ function lastMessageText(msg?: ChatMessageInfo): string {
 }
 
 export function ChatList({ initialChats, userId }: ChatListProps) {
-  const [selectedChatId, setSelectedChatId] = useState<number | null>(
-    initialChats[0]?.id ?? null,
-  );
-  const [chatMessages, setChatMessages] = useState<Record<number, ChatMessageInfo[]>>({});
-
-  const selectedChat = initialChats.find((c) => c.id === selectedChatId);
-  const initialMessages = selectedChatId ? (chatMessages[selectedChatId] ?? []) : [];
+  const [selectedChatId, setSelectedChatId] = useState<number | null>(initialChats[0]?.id ?? null);
+  const selectedChat = initialChats.find(c => c.id === selectedChatId);
+  const initialMessages: ChatMessageInfo[] = [];
 
   return (
     <Wrapper>
       <MainContainer style={{ width: '100%' }}>
         <Sidebar position='left' style={{ minWidth: '240px', maxWidth: '300px' }}>
           <ConversationList>
-            {initialChats.map((chat) => (
+            {initialChats.map(chat => (
               <Conversation
                 key={chat.id}
                 name={chat.senderName ?? `Чат #${chat.id}`}

--- a/packages/web/src/components/Chat/ChatWindow.tsx
+++ b/packages/web/src/components/Chat/ChatWindow.tsx
@@ -7,13 +7,18 @@ import {
   MainContainer,
   Message,
   MessageInput,
-  MessageList,
+  MessageList
 } from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/cjs/styles.min.css';
+import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
 import styled from 'styled-components';
 
 import { useChat } from '@/hooks/useChat';
-import { ChatContactBody, ChatDetails, ChatMessageInfo, MessageSource } from '@shared/chat/chat.types';
+import {
+  ChatContactBody,
+  ChatDetails,
+  ChatMessageInfo,
+  MessageSource
+} from '@shared/chat/chat.types';
 import { themeable } from '@/themes/utils';
 import { fileService, chatService } from '@/services';
 import { FileFolder } from '@shared/file/file.types';
@@ -104,18 +109,6 @@ const ContactInput = styled.input`
   min-width: 160px;
 `;
 
-const AttachButton = styled.button`
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 6px 8px;
-  color: ${themeable('primaryColor')};
-  font-size: 20px;
-  line-height: 1;
-  opacity: 0.8;
-  &:hover { opacity: 1; }
-`;
-
 const AttachmentImg = styled.img`
   max-width: 200px;
   max-height: 200px;
@@ -136,16 +129,15 @@ const CONTACT_OPTIONS = [
   { value: 'none', label: 'Без ответа' },
   { value: 'bot', label: 'Анонимно через бот' },
   { value: 'tel', label: 'По телефону' },
-  { value: 'email', label: 'На e-mail' },
+  { value: 'email', label: 'На e-mail' }
 ];
 
 export function ChatWindow({
   chatId,
   initialMessages,
-  currentUserId,
   isOwner = false,
   title,
-  initialContact,
+  initialContact
 }: ChatWindowProps) {
   const { messages, connected, sendMessage } = useChat({ chatId, initialMessages });
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -161,14 +153,14 @@ export function ChatWindow({
       const body: ChatContactBody = { contactType: type, contactValue: value || undefined };
       await chatService.updateContact(body, chatId).catch(() => {});
     },
-    [chatId],
+    [chatId]
   );
 
   const handleSend = useCallback(
     (text: string) => {
       if (text.trim()) sendMessage(text.trim());
     },
-    [sendMessage],
+    [sendMessage]
   );
 
   const handleAttach = useCallback(async () => {
@@ -199,9 +191,9 @@ export function ChatWindow({
             <span>Способ связи:</span>
             <ContactSelect
               value={contactType}
-              onChange={(e) => handleContactChange(e.target.value, contactValue)}
+              onChange={e => handleContactChange(e.target.value, contactValue)}
             >
-              {CONTACT_OPTIONS.map((o) => (
+              {CONTACT_OPTIONS.map(o => (
                 <option key={o.value} value={o.value}>
                   {o.label}
                 </option>
@@ -212,7 +204,7 @@ export function ChatWindow({
                 type={contactType === 'email' ? 'email' : 'tel'}
                 placeholder={contactType === 'email' ? 'your@email.com' : '+7...'}
                 value={contactValue}
-                onChange={(e) => setContactValue(e.target.value)}
+                onChange={e => setContactValue(e.target.value)}
                 onBlur={() => handleContactChange(contactType, contactValue)}
               />
             )}
@@ -228,18 +220,13 @@ export function ChatWindow({
             </ConversationHeader>
           )}
           <MessageList>
-            {messages.map((msg) => {
+            {messages.map(msg => {
               const direction =
-                (msg.source === MessageSource.Sender) !== isOwner
-                  ? 'incoming'
-                  : 'outgoing';
+                (msg.source === MessageSource.Sender) !== isOwner ? 'incoming' : 'outgoing';
 
               if (msg.attachmentUrl) {
                 return (
-                  <Message
-                    key={msg.id}
-                    model={{ direction, position: 'single' }}
-                  >
+                  <Message key={msg.id} model={{ direction, position: 'single' }}>
                     <Message.CustomContent>
                       <AttachmentImg src={msg.attachmentUrl} alt='attachment' />
                       {msg.text && <div>{msg.text}</div>}
@@ -255,7 +242,7 @@ export function ChatWindow({
                     message: msg.text,
                     direction,
                     position: 'single',
-                    sentTime: msg.createdAt,
+                    sentTime: msg.createdAt
                   }}
                 />
               );
@@ -265,24 +252,17 @@ export function ChatWindow({
             placeholder={connected ? 'Сообщение...' : 'Соединение...'}
             onSend={handleSend}
             disabled={!connected || uploading}
-            attachButton={false}
+            attachButton
+            onAttachClick={() => fileInputRef.current?.click()}
             sendButton
-          >
-            <AttachButton
-              as='label'
-              title='Прикрепить изображение'
-              style={{ cursor: 'pointer' }}
-            >
-              📎
-              <input
-                ref={fileInputRef}
-                type='file'
-                accept='image/*'
-                style={{ display: 'none' }}
-                onChange={handleAttach}
-              />
-            </AttachButton>
-          </MessageInput>
+          />
+          <input
+            ref={fileInputRef}
+            type='file'
+            accept='image/*'
+            style={{ display: 'none' }}
+            onChange={handleAttach}
+          />
         </ChatContainer>
       </MainContainer>
     </Wrapper>

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -24,7 +24,7 @@ export function useChat({ chatId, initialMessages = [] }: UseChatOptions) {
     const socket = io(`${socketUrl}/chat`, {
       path: BACKEND_URL.startsWith('/') ? `${BACKEND_URL}/socket.io` : '/socket.io',
       auth: token ? { token } : undefined,
-      withCredentials: true,
+      withCredentials: true
     });
 
     socketRef.current = socket;
@@ -37,8 +37,8 @@ export function useChat({ chatId, initialMessages = [] }: UseChatOptions) {
     socket.on('disconnect', () => setConnected(false));
 
     socket.on(CHAT_EVENTS.NEW_MESSAGE, (msg: ChatMessageInfo) => {
-      setMessages((prev) => {
-        if (prev.some((m) => m.id === msg.id)) return prev;
+      setMessages(prev => {
+        if (prev.some(m => m.id === msg.id)) return prev;
         return [...prev, msg];
       });
     });
@@ -55,10 +55,10 @@ export function useChat({ chatId, initialMessages = [] }: UseChatOptions) {
       socketRef.current?.emit(CHAT_EVENTS.SEND_MESSAGE, {
         chatId,
         text,
-        attachmentUrl,
+        attachmentUrl
       });
     },
-    [chatId],
+    [chatId]
   );
 
   return { messages, connected, sendMessage };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Build** (`build-backend`, `build-web`) — запускаются на `ubuntu-latest` (GitHub runners) параллельно, собирают Docker-образы и пушат в `ghcr.io` с GHA layer cache
- **Deploy** (`deploy-backend`, `deploy-web`) — подключаются по SSH к `beznomera.net`, пулят образ из `ghcr.io` и перезапускают контейнер; `deploy-web` ждёт `deploy-backend`
- **Health check** — после каждого деплоя: цикл 10 попыток × 30 секунд ожидания
- **Clean** — по SSH запускает `docker image/container prune` на сервере (вместо self-hosted)

## Необходимые секреты (добавить в Settings → Secrets)

| Секрет | Значение |
|---|---|
| `SERVER_SSH_KEY` | Приватный SSH-ключ для `root@beznomera.net` |
| `SERVER_KNOWN_HOSTS` | Вывод `ssh-keyscan beznomera.net` |

`BACKEND_API_TOKEN` и `GITHUB_TOKEN` (автоматический) уже используются.

## Test plan

- [ ] Добавить секреты `SERVER_SSH_KEY` и `SERVER_KNOWN_HOSTS`
- [ ] Убедиться, что `ghcr.io` пакеты репозитория открыты (или сервер может пулить с токеном)
- [ ] Сделать push в `master` и проверить прохождение всех job'ов

https://claude.ai/code/session_01PFjVKQTtP5xNcdzXqixYYL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFjVKQTtP5xNcdzXqixYYL)_