### PR TITLE
fix(ci): replace known_hosts with fingerprint in appleboy/ssh-action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -86,7 +86,7 @@ jobs:
           host: beznomera.net
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          fingerprint: ${{ secrets.SERVER_FINGERPRINT }}
           envs: GHCR_TOKEN,GHCR_ACTOR,IMAGE_TAG
           script: |
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
@@ -105,7 +105,7 @@ jobs:
           host: beznomera.net
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          fingerprint: ${{ secrets.SERVER_FINGERPRINT }}
           script: |
             for i in $(seq 1 10); do
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:4444/ 2>/dev/null || echo "000")
@@ -136,7 +136,7 @@ jobs:
           host: beznomera.net
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          fingerprint: ${{ secrets.SERVER_FINGERPRINT }}
           envs: GHCR_TOKEN,GHCR_ACTOR,IMAGE_TAG
           script: |
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
@@ -153,7 +153,7 @@ jobs:
           host: beznomera.net
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          fingerprint: ${{ secrets.SERVER_FINGERPRINT }}
           script: |
             for i in $(seq 1 10); do
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:4000/ 2>/dev/null || echo "000")
@@ -180,7 +180,7 @@ jobs:
           host: beznomera.net
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ secrets.SERVER_KNOWN_HOSTS }}
+          fingerprint: ${{ secrets.SERVER_FINGERPRINT }}
           script: |
             docker image prune -f
             docker container prune -f


### PR DESCRIPTION
Closes #27

`known_hosts` не является валидным параметром для `appleboy/ssh-action@v1.2.0`. Правильный параметр — `fingerprint` (SHA256 хеш публичного ключа сервера).

Добавить секрет `SERVER_FINGERPRINT`:
```bash
ssh-keyscan -t rsa beznomera.net | ssh-keygen -lf - -E sha256
# взять часть после SHA256:
```

https://claude.ai/code/session_01PFjVKQTtP5xNcdzXqixYYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFjVKQTtP5xNcdzXqixYYL)_