### PR TITLE
fix: load chat messages on selection, custom sidebar styling

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -61,7 +61,9 @@
     "typeorm-naming-strategies": "^4.1.0",
     "typeorm-transactional": "^0.5.0",
     "useragent": "^2.3.0",
-    "web-push": "3.6.7"
+    "web-push": "3.6.7",
+    "@nestjs/websockets": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/packages/backend/src/app/chat/chat.controller.ts
+++ b/packages/backend/src/app/chat/chat.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { ChatService } from './chat.service';
+import { JwtAuthGuard, OptionalJwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../users/user.decorator';
+import { RequestUser } from '@paulislava/shared/user/user.types';
+import CHAT_API, { CHAT_CODE_PARAM, CHAT_ID_PARAM } from '@paulislava/shared/chat/chat.api';
+import {
+  ChatContactBody,
+  ChatDetails,
+  ChatInfo,
+  ChatMessageInfo,
+  ChatSendMessageBody,
+} from '@paulislava/shared/chat/chat.types';
+import { ConfigService } from '../config/config.service';
+
+class SendOwnerMessageDto implements ChatSendMessageBody {
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+
+  chatId: number;
+
+  @IsOptional()
+  @IsString()
+  attachmentUrl?: string;
+}
+
+class UpdateContactDto implements ChatContactBody {
+  @IsString()
+  @IsNotEmpty()
+  contactType: string;
+
+  @IsOptional()
+  @IsString()
+  contactValue?: string;
+}
+
+@Controller(CHAT_API.path)
+export class ChatController {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get(CHAT_API.backendRoutes.myChats)
+  @UseGuards(JwtAuthGuard)
+  myChats(@CurrentUser() user: RequestUser): Promise<ChatInfo[]> {
+    return this.chatService.getMyChats(user.userId);
+  }
+
+  @Get(CHAT_API.backendRoutes.chatDetails)
+  @UseGuards(JwtAuthGuard)
+  chatDetails(
+    @Param(CHAT_ID_PARAM, ParseIntPipe) chatId: number,
+    @CurrentUser() user: RequestUser,
+  ): Promise<ChatDetails> {
+    return this.chatService.getChatDetails(chatId, user.userId);
+  }
+
+  @Get(CHAT_API.backendRoutes.chatByCarCode)
+  @UseGuards(OptionalJwtAuthGuard)
+  chatByCarCode(
+    @Param(CHAT_CODE_PARAM) code: string,
+    @Req() req: Request,
+    @CurrentUser(true) user?: RequestUser,
+  ): Promise<ChatDetails> {
+    const anonymousId = req.cookies?.[this.configService.auth.anonymousIdCookie];
+    return this.chatService.getChatByCarCode(code, user?.userId, anonymousId);
+  }
+
+  @Post(CHAT_API.backendRoutes.sendOwnerMessage)
+  @UseGuards(JwtAuthGuard)
+  sendOwnerMessage(
+    @Body() body: SendOwnerMessageDto,
+    @Param(CHAT_ID_PARAM, ParseIntPipe) chatId: number,
+    @CurrentUser() user: RequestUser,
+  ): Promise<ChatMessageInfo> {
+    return this.chatService.sendOwnerMessage(chatId, body.text, body.attachmentUrl, user.userId);
+  }
+
+  @Post(CHAT_API.backendRoutes.updateContact)
+  @UseGuards(OptionalJwtAuthGuard)
+  updateContact(
+    @Body() body: UpdateContactDto,
+    @Param(CHAT_ID_PARAM, ParseIntPipe) chatId: number,
+    @Req() req: Request,
+    @CurrentUser(true) user?: RequestUser,
+  ): Promise<void> {
+    const anonymousId = req.cookies?.[this.configService.auth.anonymousIdCookie];
+    return this.chatService.updateContact(chatId, body, user?.userId, anonymousId);
+  }
+}

--- a/packages/backend/src/app/chat/chat.gateway.ts
+++ b/packages/backend/src/app/chat/chat.gateway.ts
@@ -1,0 +1,92 @@
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { parse as parseCookies } from 'cookie';
+
+import { ChatService } from './chat.service';
+import { ConfigService } from '../config/config.service';
+import { CHAT_EVENTS, ChatMessageInfo } from '@paulislava/shared/chat/chat.types';
+
+@WebSocketGateway({
+  namespace: '/chat',
+  cors: { origin: '*', credentials: true },
+})
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async handleConnection(client: Socket) {
+    const token =
+      client.handshake.auth?.token ||
+      client.handshake.headers?.['x-user-token'];
+
+    if (token) {
+      try {
+        const payload = this.jwtService.verify(token, {
+          secret: this.configService.auth.jwtSecret,
+        });
+        client.data.userId = payload.userId;
+      } catch {
+        // anonymous
+      }
+    }
+
+    const rawCookie = client.handshake.headers?.cookie ?? '';
+    if (rawCookie) {
+      const parsed = parseCookies(rawCookie);
+      const cookieName = this.configService.auth.anonymousIdCookie;
+      client.data.anonymousId = parsed[cookieName];
+    }
+  }
+
+  handleDisconnect(_client: Socket) {}
+
+  @SubscribeMessage(CHAT_EVENTS.JOIN_CHAT)
+  handleJoinChat(client: Socket, chatId: number) {
+    client.join(`chat:${chatId}`);
+  }
+
+  @SubscribeMessage(CHAT_EVENTS.LEAVE_CHAT)
+  handleLeaveChat(client: Socket, chatId: number) {
+    client.leave(`chat:${chatId}`);
+  }
+
+  @SubscribeMessage(CHAT_EVENTS.SEND_MESSAGE)
+  async handleSendMessage(
+    client: Socket,
+    payload: { chatId: number; text: string; attachmentUrl?: string },
+  ) {
+    const { chatId, text, attachmentUrl } = payload;
+    const userId = client.data.userId as number | undefined;
+    const anonymousId = client.data.anonymousId as string | undefined;
+
+    try {
+      const message = await this.chatService.handleWebSocketMessage(
+        chatId,
+        text,
+        attachmentUrl,
+        userId,
+        anonymousId,
+      );
+      this.server.to(`chat:${chatId}`).emit(CHAT_EVENTS.NEW_MESSAGE, message);
+    } catch (err: any) {
+      client.emit(CHAT_EVENTS.ERROR, err?.message ?? 'Error');
+    }
+  }
+
+  emitNewMessage(chatId: number, message: ChatMessageInfo) {
+    this.server.to(`chat:${chatId}`).emit(CHAT_EVENTS.NEW_MESSAGE, message);
+  }
+}

--- a/packages/backend/src/app/chat/chat.module.ts
+++ b/packages/backend/src/app/chat/chat.module.ts
@@ -1,17 +1,30 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
 import { Chat } from '../entities/chat/chat.entity';
 import { ChatMessage } from '../entities/chat/message.entity';
 import { AnonymousUser } from '../entities/user/anonymous-user.entity';
 
 import { ConfigModule } from '../config/config.module';
+import { ConfigService } from '../config/config.service';
 import { ChatService } from './chat.service';
+import { ChatController } from './chat.controller';
+import { ChatGateway } from './chat.gateway';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([Chat, ChatMessage, AnonymousUser]),
     ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory(configService: ConfigService): JwtModuleOptions {
+        return { secret: configService.auth.jwtSecret };
+      },
+    }),
   ],
-  providers: [ChatService],
-  exports: [ChatService],
+  providers: [ChatService, ChatGateway],
+  controllers: [ChatController],
+  exports: [ChatService, ChatGateway],
 })
 export class ChatModule {}

--- a/packages/backend/src/app/chat/chat.service.ts
+++ b/packages/backend/src/app/chat/chat.service.ts
@@ -1,19 +1,28 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere, DeepPartial } from 'typeorm';
 import { Chat } from '../entities/chat/chat.entity';
 import { ChatMessage } from '../entities/chat/message.entity';
 import { AnonymousUser } from '../entities/user/anonymous-user.entity';
+import { Car } from '../entities/car/car.entity';
 import { TelegramService } from '../telegram/telegram.service';
 import { ConfigService } from '../config/config.service';
 import { Response, Request } from 'express';
 import { RequestUser } from '@paulislava/shared/user/user.types';
 import userAgentParser from 'useragent';
 import { ChatMessageData } from './chat.types';
-import { Car } from '../entities/car/car.entity';
+import {
+  ChatContactBody,
+  ChatDetails,
+  ChatInfo,
+  ChatMessageInfo,
+  MessageSource,
+} from '@paulislava/shared/chat/chat.types';
 
 @Injectable()
 export class ChatService {
+  private readonly logger = new Logger(ChatService.name);
+
   constructor(
     @InjectRepository(Chat) private readonly chatRepository: Repository<Chat>,
     @InjectRepository(ChatMessage)
@@ -23,6 +32,212 @@ export class ChatService {
     private readonly telegramService: TelegramService,
     private readonly configService: ConfigService,
   ) {}
+
+  mapMessageToInfo(msg: ChatMessage, chat: Chat): ChatMessageInfo {
+    const source =
+      msg.userId != null && msg.userId === chat.reciever?.id
+        ? MessageSource.Reciever
+        : MessageSource.Sender;
+
+    return {
+      id: msg.id,
+      chatId: msg.chatId,
+      text: msg.text,
+      userId: msg.userId,
+      createdAt: msg.createdAt.toISOString(),
+      source,
+      attachmentUrl: msg.attachmentUrl ?? null,
+    };
+  }
+
+  private mapChatToInfo(chat: Chat, messages: ChatMessage[]): ChatInfo {
+    const senderName =
+      chat.sender?.name ??
+      chat.anonymousSender?.id?.slice(0, 8) ??
+      'Анонимный';
+
+    const lastMessage = messages[0]
+      ? this.mapMessageToInfo(messages[0], chat)
+      : undefined;
+
+    return {
+      id: chat.id,
+      createdAt: chat.createdAt.toISOString(),
+      lastMessage,
+      senderName,
+      contactType: chat.contactType,
+      contactValue: chat.contactValue,
+      car: chat.messages?.[0]?.car
+        ? {
+            id: chat.messages[0].car.id,
+            no: chat.messages[0].car.no,
+            code: chat.messages[0].car.code,
+          }
+        : undefined,
+    };
+  }
+
+  private mapChatToDetails(chat: Chat): ChatDetails {
+    const senderName =
+      chat.sender?.name ??
+      chat.anonymousSender?.id?.slice(0, 8) ??
+      'Анонимный';
+
+    const messages = (chat.messages ?? []).map((m) => this.mapMessageToInfo(m, chat));
+
+    const firstMsgCar = chat.messages?.find((m) => m.car)?.car;
+
+    return {
+      id: chat.id,
+      createdAt: chat.createdAt.toISOString(),
+      messages,
+      senderName,
+      contactType: chat.contactType,
+      contactValue: chat.contactValue,
+      car: firstMsgCar
+        ? { id: firstMsgCar.id, no: firstMsgCar.no, code: firstMsgCar.code }
+        : undefined,
+    };
+  }
+
+  async getMyChats(userId: number): Promise<ChatInfo[]> {
+    const chats = await this.chatRepository.find({
+      where: { reciever: { id: userId } },
+      relations: ['sender', 'anonymousSender', 'messages', 'messages.car'],
+      order: { createdAt: 'DESC' },
+    });
+
+    return chats.map((chat) => {
+      const sorted = (chat.messages ?? []).sort(
+        (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+      );
+      return this.mapChatToInfo(chat, sorted);
+    });
+  }
+
+  async getChatDetails(chatId: number, userId: number): Promise<ChatDetails> {
+    const chat = await this.chatRepository.findOne({
+      where: { id: chatId },
+      relations: ['reciever', 'sender', 'anonymousSender', 'messages', 'messages.car'],
+      order: { messages: { createdAt: 'ASC' } },
+    });
+
+    if (!chat) throw new NotFoundException('Chat not found');
+
+    const isParticipant =
+      chat.reciever?.id === userId || chat.sender?.id === userId;
+
+    if (!isParticipant) throw new ForbiddenException('Access denied');
+
+    return this.mapChatToDetails(chat);
+  }
+
+  async getChatByCarCode(
+    code: string,
+    userId?: number,
+    anonymousId?: string,
+  ): Promise<ChatDetails> {
+    const car = await this.messagesRepository.manager
+      .getRepository(Car)
+      .findOne({ where: { code }, relations: ['owner'] });
+
+    if (!car) throw new NotFoundException('Car not found');
+
+    const chat = await this.getOrCreateChat(car, userId, anonymousId);
+
+    const fullChat = await this.chatRepository.findOne({
+      where: { id: chat.id },
+      relations: ['reciever', 'sender', 'anonymousSender', 'messages', 'messages.car'],
+      order: { messages: { createdAt: 'ASC' } },
+    });
+
+    return this.mapChatToDetails(fullChat!);
+  }
+
+  async sendOwnerMessage(
+    chatId: number,
+    text: string,
+    attachmentUrl: string | undefined,
+    ownerId: number,
+  ): Promise<ChatMessageInfo> {
+    const chat = await this.chatRepository.findOne({
+      where: { id: chatId, reciever: { id: ownerId } },
+      relations: ['reciever', 'sender', 'anonymousSender'],
+    });
+
+    if (!chat) throw new ForbiddenException('Access denied');
+
+    const saved = await this.messagesRepository.save({
+      chat,
+      chatId,
+      text,
+      userId: ownerId,
+      attachmentUrl: attachmentUrl ?? null,
+      telegramId: null,
+      sourceTelegramId: null,
+    });
+
+    return this.mapMessageToInfo(saved, chat);
+  }
+
+  async handleWebSocketMessage(
+    chatId: number,
+    text: string,
+    attachmentUrl: string | undefined,
+    userId?: number,
+    anonymousId?: string,
+  ): Promise<ChatMessageInfo> {
+    const chat = await this.chatRepository.findOne({
+      where: { id: chatId },
+      relations: ['reciever', 'sender', 'anonymousSender'],
+    });
+
+    if (!chat) throw new NotFoundException('Chat not found');
+
+    const isOwner = userId != null && chat.reciever?.id === userId;
+    const isSender =
+      (userId != null && chat.sender?.id === userId) ||
+      (anonymousId != null && chat.anonymousSender?.id === anonymousId);
+
+    if (!isOwner && !isSender) throw new ForbiddenException('Access denied');
+
+    const saved = await this.messagesRepository.save({
+      chat,
+      chatId,
+      text,
+      userId: userId ?? null,
+      attachmentUrl: attachmentUrl ?? null,
+      telegramId: null,
+      sourceTelegramId: null,
+    });
+
+    return this.mapMessageToInfo(saved, chat);
+  }
+
+  async updateContact(
+    chatId: number,
+    body: ChatContactBody,
+    userId?: number,
+    anonymousId?: string,
+  ): Promise<void> {
+    const chat = await this.chatRepository.findOne({
+      where: { id: chatId },
+      relations: ['sender', 'anonymousSender'],
+    });
+
+    if (!chat) throw new NotFoundException('Chat not found');
+
+    const isSender =
+      (userId != null && chat.sender?.id === userId) ||
+      (anonymousId != null && chat.anonymousSender?.id === anonymousId);
+
+    if (!isSender) throw new ForbiddenException('Only sender can update contact');
+
+    await this.chatRepository.update(chatId, {
+      contactType: body.contactType,
+      contactValue: body.contactValue ?? null,
+    });
+  }
 
   private async getOrCreateAnonymousId(
     anonymousId: string | undefined,
@@ -111,6 +326,7 @@ export class ChatService {
 
     await this.messagesRepository.save({
       chat,
+      chatId: chat.id,
       car,
       text,
       location: coords
@@ -121,6 +337,7 @@ export class ChatService {
         : undefined,
       userId,
       telegramId: tgMessage?.message_id.toString() ?? null,
+      attachmentUrl: null,
     });
   }
 
@@ -158,6 +375,7 @@ export class ChatService {
 
     await this.messagesRepository.save({
       chat,
+      chatId: chat.id,
       car,
       text,
       location: coords
@@ -168,6 +386,7 @@ export class ChatService {
         : undefined,
       userId,
       telegramId: tgMessage?.message_id.toString() ?? null,
+      attachmentUrl: null,
     });
 
     if (newAnonymousId) {

--- a/packages/backend/src/app/entities/chat/chat.entity.ts
+++ b/packages/backend/src/app/entities/chat/chat.entity.ts
@@ -1,5 +1,6 @@
 import {
   BaseEntity,
+  Column,
   CreateDateColumn,
   Entity,
   ManyToOne,
@@ -26,6 +27,12 @@ export class Chat extends BaseEntity {
 
   @OneToMany(() => ChatMessage, (message) => message.chat)
   messages: ChatMessage[];
+
+  @Column({ nullable: true })
+  contactType: string | null;
+
+  @Column({ nullable: true })
+  contactValue: string | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/packages/backend/src/app/entities/chat/message.entity.ts
+++ b/packages/backend/src/app/entities/chat/message.entity.ts
@@ -52,4 +52,7 @@ export class ChatMessage extends BaseEntity {
 
   @Column({ type: 'jsonb', nullable: true })
   location?: LocationInfo;
+
+  @Column({ nullable: true })
+  attachmentUrl: string | null;
 }

--- a/packages/backend/src/app/migrations/1747051200000-ChatMessengerFields.ts
+++ b/packages/backend/src/app/migrations/1747051200000-ChatMessengerFields.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChatMessengerFields1747051200000 implements MigrationInterface {
+  name = 'ChatMessengerFields1747051200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "chat" ADD "contactType" character varying`);
+    await queryRunner.query(`ALTER TABLE "chat" ADD "contactValue" character varying`);
+    await queryRunner.query(`ALTER TABLE "chat_message" ADD "attachmentUrl" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "chat_message" DROP COLUMN "attachmentUrl"`);
+    await queryRunner.query(`ALTER TABLE "chat" DROP COLUMN "contactValue"`);
+    await queryRunner.query(`ALTER TABLE "chat" DROP COLUMN "contactType"`);
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { IoAdapter } from '@nestjs/platform-socket.io';
 
 import { AppModule } from './app.module';
 import { ASSETS_FILE_PATH, ASSETS_URI_PATH } from './constants';
@@ -53,6 +54,8 @@ async function bootstrap() {
     console.info(`Global route prefix: ${routePrefix}`);
     app.setGlobalPrefix(routePrefix);
   }
+
+  app.useWebSocketAdapter(new IoAdapter(app));
 
   app.useGlobalPipes(new ValidationPipe());
 

--- a/packages/shared/src/chat/chat.api.ts
+++ b/packages/shared/src/chat/chat.api.ts
@@ -1,0 +1,36 @@
+import { APIRoutes, apiInfo } from '../api-routes';
+import {
+  ChatContactBody,
+  ChatDetails,
+  ChatInfo,
+  ChatMessageInfo,
+  ChatSendMessageBody,
+} from './chat.types';
+
+export interface ChatApi {
+  myChats(...args: any[]): Promise<ChatInfo[]>;
+  chatDetails(chatId: number, ...args: any[]): Promise<ChatDetails>;
+  chatByCarCode(code: string, ...args: any[]): Promise<ChatDetails>;
+  sendOwnerMessage(body: ChatSendMessageBody, chatId: number, ...args: any[]): Promise<ChatMessageInfo>;
+  updateContact(body: ChatContactBody, chatId: number, ...args: any[]): Promise<void>;
+}
+
+export const CHAT_ID_PARAM = 'chatId';
+export const CHAT_CODE_PARAM = 'code';
+
+const CHAT_ROUTES: APIRoutes<ChatApi> = {
+  myChats: 'my',
+  chatDetails: (chatId) => `${chatId || `:${CHAT_ID_PARAM}`}`,
+  chatByCarCode: (code) => `by-car/${code || `:${CHAT_CODE_PARAM}`}`,
+  sendOwnerMessage: {
+    path: (chatId) => `${chatId || `:${CHAT_ID_PARAM}`}/message`,
+    method: 'POST',
+  },
+  updateContact: {
+    path: (chatId) => `${chatId || `:${CHAT_ID_PARAM}`}/contact`,
+    method: 'POST',
+  },
+};
+
+const CHAT_API = apiInfo(CHAT_ROUTES, 'chat');
+export default CHAT_API;

--- a/packages/shared/src/chat/chat.types.ts
+++ b/packages/shared/src/chat/chat.types.ts
@@ -2,3 +2,60 @@ export enum MessageSource {
   Sender = 'sender',
   Reciever = 'reciever'
 }
+
+export interface ChatMessageInfo {
+  id: number;
+  chatId: number;
+  text: string;
+  userId: number | null;
+  createdAt: string;
+  source: MessageSource;
+  attachmentUrl?: string | null;
+}
+
+export interface ChatInfo {
+  id: number;
+  createdAt: string;
+  lastMessage?: ChatMessageInfo;
+  senderName?: string;
+  contactType?: string | null;
+  contactValue?: string | null;
+  car?: {
+    id: number;
+    no: string;
+    code: string;
+  };
+}
+
+export interface ChatDetails {
+  id: number;
+  createdAt: string;
+  messages: ChatMessageInfo[];
+  senderName?: string;
+  contactType?: string | null;
+  contactValue?: string | null;
+  car?: {
+    id: number;
+    no: string;
+    code: string;
+  };
+}
+
+export interface ChatSendMessageBody {
+  chatId: number;
+  text: string;
+  attachmentUrl?: string;
+}
+
+export interface ChatContactBody {
+  contactType: string;
+  contactValue?: string;
+}
+
+export const CHAT_EVENTS = {
+  JOIN_CHAT: 'chat:join',
+  LEAVE_CHAT: 'chat:leave',
+  SEND_MESSAGE: 'chat:send_message',
+  NEW_MESSAGE: 'chat:new_message',
+  ERROR: 'chat:error',
+} as const;

--- a/packages/shared/src/file/file.types.ts
+++ b/packages/shared/src/file/file.types.ts
@@ -6,5 +6,6 @@ export type FileInfo = {
 
 export enum FileFolder {
   Cars = 'user-car',
-  Temp = 'temp'
+  Temp = 'temp',
+  Chat = 'chat'
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -24,7 +24,10 @@
     "react-qrcode-logo": "4.0.0",
     "react-textarea-autosize": "^8.5.9",
     "styled-components": "^6.1.18",
-    "telegram-login-button": "^0.1.0"
+    "telegram-login-button": "^0.1.0",
+    "socket.io-client": "^4.8.1",
+    "@chatscope/chat-ui-kit-react": "^2.0.3",
+    "@chatscope/chat-ui-kit-styles": "^1.4.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/packages/web/src/app/g/[code]/chat/page.tsx
+++ b/packages/web/src/app/g/[code]/chat/page.tsx
@@ -2,7 +2,7 @@ import { carService } from '@/services';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { extractCode } from '@/utils/params';
-import { CarMessagePage } from '@/components/CarInfo/CarMessage';
+import { CarChatPage } from '@/components/CarInfo/CarChatPage';
 
 export async function generateStaticParams() {
   try {
@@ -66,7 +66,7 @@ export default async function Page({ params }: PromiseParams<{ code: string }>) 
   try {
     const info = await carService.info(code);
 
-    return <CarMessagePage info={info} code={code} />;
+    return <CarChatPage info={info} code={code} />;
   } catch {
     notFound();
   }

--- a/packages/web/src/app/messages/page.tsx
+++ b/packages/web/src/app/messages/page.tsx
@@ -1,0 +1,16 @@
+import { AuthComponent, withUser } from '@/context/Auth/withUser';
+import { createApi } from '@/services';
+import { AUTH_COOKIE_NAME } from '@/helpers/constants';
+import { cookies } from 'next/headers';
+import { ChatList } from '@/components/Chat/ChatList';
+
+const MessagesPage: AuthComponent = async ({ user }) => {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+  const api = createApi(token);
+  const chats = await api.chat.myChats().catch(() => []);
+
+  return <ChatList initialChats={chats} userId={user.userId} />;
+};
+
+export default withUser(MessagesPage, false);

--- a/packages/web/src/components/CarInfo/CarChatPage.tsx
+++ b/packages/web/src/components/CarInfo/CarChatPage.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ChatDetails } from '@shared/chat/chat.types';
+import { chatService } from '@/services';
+import { ChatWindow } from '@/components/Chat/ChatWindow';
+import { CarInfoProps } from './CarInfo.types';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+`;
+
+const Header = styled.div`
+  padding: 12px 16px;
+  font-weight: 600;
+  font-size: 15px;
+  border-bottom: 1px solid var(--cs-message-input-border-color, #e0e0e0);
+`;
+
+export const CarChatPage: React.FC<CarInfoProps> = ({ info, code }) => {
+  const [chat, setChat] = useState<ChatDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    chatService
+      .chatByCarCode(code)
+      .then(setChat)
+      .catch(() => setChat(null))
+      .finally(() => setLoading(false));
+  }, [code]);
+
+  const title = [info.no, info.brandRaw ?? info.brand?.title, info.model]
+    .filter(Boolean)
+    .join(' ');
+
+  if (loading) return null;
+
+  return (
+    <Wrapper>
+      <Header>{title}</Header>
+      {chat ? (
+        <ChatWindow
+          chatId={chat.id}
+          initialMessages={chat.messages}
+          isOwner={false}
+          initialContact={{ contactType: chat.contactType ?? undefined, contactValue: chat.contactValue ?? undefined }}
+        />
+      ) : (
+        <div style={{ padding: 20 }}>Не удалось загрузить чат</div>
+      )}
+    </Wrapper>
+  );
+};

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Conversation,
+  ConversationList,
+  MainContainer,
+  Sidebar,
+} from '@chatscope/chat-ui-kit-react';
+import '@chatscope/chat-ui-kit-styles/dist/cjs/styles.min.css';
+import styled from 'styled-components';
+
+import { ChatInfo, ChatMessageInfo } from '@shared/chat/chat.types';
+import { themeable } from '@/themes/utils';
+import { ChatWindow } from './ChatWindow';
+
+const Wrapper = styled.div`
+  height: calc(100vh - 64px);
+  display: flex;
+
+  --cs-conversation-list-background: ${themeable('secondaryBackground')};
+  --cs-conversation-background: ${themeable('secondaryBackground')};
+  --cs-conversation-color: ${themeable('textColor')};
+  --cs-sidebar-background: ${themeable('secondaryBackground')};
+
+  .cs-sidebar {
+    background: ${themeable('secondaryBackground')};
+    border-right: 1px solid ${themeable('mainBackgroundColor')};
+  }
+
+  .cs-conversation-list {
+    background: ${themeable('secondaryBackground')};
+  }
+
+  .cs-conversation {
+    background: ${themeable('secondaryBackground')};
+    color: ${themeable('textColor')};
+
+    &:hover, &[data-active='true'] {
+      background: ${themeable('mainBackgroundColor')};
+    }
+  }
+
+  .cs-conversation__name {
+    color: ${themeable('textColor')};
+  }
+
+  .cs-conversation__info {
+    color: ${themeable('textColor')};
+    opacity: 0.6;
+  }
+`;
+
+const EmptyState = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${themeable('textColor')};
+  opacity: 0.5;
+  font-size: 15px;
+`;
+
+interface ChatListProps {
+  initialChats: ChatInfo[];
+  userId: number;
+}
+
+function formatContact(contactType?: string | null, contactValue?: string | null): string {
+  if (contactType === 'tel' && contactValue) return `Тел: ${contactValue}`;
+  if (contactType === 'email' && contactValue) return `E-mail: ${contactValue}`;
+  if (contactType === 'bot') return 'Через бот';
+  return 'Анонимно';
+}
+
+function lastMessageText(msg?: ChatMessageInfo): string {
+  if (!msg) return '';
+  if (msg.attachmentUrl && !msg.text) return '📎 Изображение';
+  return msg.text ?? '';
+}
+
+export function ChatList({ initialChats, userId }: ChatListProps) {
+  const [selectedChatId, setSelectedChatId] = useState<number | null>(
+    initialChats[0]?.id ?? null,
+  );
+  const [chatMessages, setChatMessages] = useState<Record<number, ChatMessageInfo[]>>({});
+
+  const selectedChat = initialChats.find((c) => c.id === selectedChatId);
+  const initialMessages = selectedChatId ? (chatMessages[selectedChatId] ?? []) : [];
+
+  return (
+    <Wrapper>
+      <MainContainer style={{ width: '100%' }}>
+        <Sidebar position='left' style={{ minWidth: '240px', maxWidth: '300px' }}>
+          <ConversationList>
+            {initialChats.map((chat) => (
+              <Conversation
+                key={chat.id}
+                name={chat.senderName ?? `Чат #${chat.id}`}
+                info={
+                  chat.lastMessage
+                    ? lastMessageText(chat.lastMessage)
+                    : formatContact(chat.contactType, chat.contactValue)
+                }
+                active={chat.id === selectedChatId}
+                onClick={() => setSelectedChatId(chat.id)}
+              />
+            ))}
+          </ConversationList>
+        </Sidebar>
+
+        {selectedChat ? (
+          <ChatWindow
+            chatId={selectedChat.id}
+            initialMessages={initialMessages}
+            currentUserId={userId}
+            isOwner
+            title={
+              selectedChat.senderName ??
+              `Чат #${selectedChat.id}` +
+                (selectedChat.contactType
+                  ? ' · ' + formatContact(selectedChat.contactType, selectedChat.contactValue)
+                  : '')
+            }
+          />
+        ) : (
+          <EmptyState>Выберите чат</EmptyState>
+        )}
+      </MainContainer>
+    </Wrapper>
+  );
+}

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -41,7 +41,8 @@ const ChatItem = styled.div<{ $active?: boolean }>`
   transition: background 0.15s;
 
   &:hover {
-    background: ${({ $active }) => ($active ? themeable('primaryColor') : themeable('mainBackgroundColor'))};
+    background: ${({ $active }) =>
+      $active ? themeable('primaryColor') : themeable('mainBackgroundColor')};
   }
 `;
 
@@ -118,33 +119,29 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
       setLoading(true);
       try {
         const details = await chatService.chatDetails(chatId);
-        setDetailsCache((prev) => ({ ...prev, [chatId]: details }));
+        setDetailsCache(prev => ({ ...prev, [chatId]: details }));
       } finally {
         setLoading(false);
       }
     },
-    [detailsCache],
+    [detailsCache]
   );
 
   useEffect(() => {
     if (selectedId != null) loadChat(selectedId);
   }, [selectedId, loadChat]);
 
-  const selectedChat = initialChats.find((c) => c.id === selectedId);
+  const selectedChat = initialChats.find(c => c.id === selectedId);
   const selectedDetails = selectedId != null ? detailsCache[selectedId] : undefined;
 
   return (
     <Layout>
       <SidebarPanel>
         <SidebarHeader>Сообщения</SidebarHeader>
-        {initialChats.map((chat) => {
+        {initialChats.map(chat => {
           const active = chat.id === selectedId;
           return (
-            <ChatItem
-              key={chat.id}
-              $active={active}
-              onClick={() => setSelectedId(chat.id)}
-            >
+            <ChatItem key={chat.id} $active={active} onClick={() => setSelectedId(chat.id)}>
               <ChatItemName $active={active}>{chat.senderName ?? `Чат #${chat.id}`}</ChatItemName>
               <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
             </ChatItem>

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -1,54 +1,74 @@
 'use client';
 
-import React, { useState } from 'react';
-import {
-  Conversation,
-  ConversationList,
-  MainContainer,
-  Sidebar,
-} from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/cjs/styles.min.css';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { ChatInfo, ChatMessageInfo } from '@shared/chat/chat.types';
+import { ChatDetails, ChatInfo } from '@shared/chat/chat.types';
 import { themeable } from '@/themes/utils';
+import { chatService } from '@/services';
 import { ChatWindow } from './ChatWindow';
 
-const Wrapper = styled.div`
+const Layout = styled.div`
   height: calc(100vh - 64px);
   display: flex;
+  overflow: hidden;
+`;
 
-  --cs-conversation-list-background: ${themeable('secondaryBackground')};
-  --cs-conversation-background: ${themeable('secondaryBackground')};
-  --cs-conversation-color: ${themeable('textColor')};
-  --cs-sidebar-background: ${themeable('secondaryBackground')};
+const SidebarPanel = styled.div`
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: ${themeable('secondaryBackground')};
+  border-right: 1px solid ${themeable('mainBackgroundColor')};
+  overflow-y: auto;
+`;
 
-  .cs-sidebar {
-    background: ${themeable('secondaryBackground')};
-    border-right: 1px solid ${themeable('mainBackgroundColor')};
+const SidebarHeader = styled.div`
+  padding: 16px;
+  font-size: 17px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+  flex-shrink: 0;
+`;
+
+const ChatItem = styled.div<{ $active?: boolean }>`
+  padding: 12px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+  background: ${({ $active }) => ($active ? themeable('primaryColor') : 'transparent')};
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${({ $active }) => ($active ? themeable('primaryColor') : themeable('mainBackgroundColor'))};
   }
+`;
 
-  .cs-conversation-list {
-    background: ${themeable('secondaryBackground')};
-  }
+const ChatItemName = styled.div<{ $active?: boolean }>`
+  font-size: 14px;
+  font-weight: 600;
+  color: ${({ $active }) => ($active ? '#fff' : themeable('textColor'))};
+  margin-bottom: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
-  .cs-conversation {
-    background: ${themeable('secondaryBackground')};
-    color: ${themeable('textColor')};
+const ChatItemPreview = styled.div<{ $active?: boolean }>`
+  font-size: 12px;
+  color: ${({ $active }) => ($active ? 'rgba(255,255,255,0.75)' : themeable('textColor'))};
+  opacity: ${({ $active }) => ($active ? 1 : 0.55)};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
-    &:hover, &[data-active='true'] {
-      background: ${themeable('mainBackgroundColor')};
-    }
-  }
-
-  .cs-conversation__name {
-    color: ${themeable('textColor')};
-  }
-
-  .cs-conversation__info {
-    color: ${themeable('textColor')};
-    opacity: 0.6;
-  }
+const MainArea = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 `;
 
 const EmptyState = styled.div`
@@ -57,8 +77,9 @@ const EmptyState = styled.div`
   align-items: center;
   justify-content: center;
   color: ${themeable('textColor')};
-  opacity: 0.5;
+  opacity: 0.4;
   font-size: 15px;
+  background: ${themeable('mainBackgroundColor')};
 `;
 
 interface ChatListProps {
@@ -73,60 +94,82 @@ function formatContact(contactType?: string | null, contactValue?: string | null
   return 'Анонимно';
 }
 
-function lastMessageText(msg?: ChatMessageInfo): string {
-  if (!msg) return '';
+function previewText(chat: ChatInfo): string {
+  const msg = chat.lastMessage;
+  if (!msg) return formatContact(chat.contactType, chat.contactValue);
   if (msg.attachmentUrl && !msg.text) return '📎 Изображение';
   return msg.text ?? '';
 }
 
-export function ChatList({ initialChats, userId }: ChatListProps) {
-  const [selectedChatId, setSelectedChatId] = useState<number | null>(
-    initialChats[0]?.id ?? null,
-  );
-  const [chatMessages, setChatMessages] = useState<Record<number, ChatMessageInfo[]>>({});
+function chatTitle(chat: ChatInfo): string {
+  const name = chat.senderName ?? `Чат #${chat.id}`;
+  const contact = formatContact(chat.contactType, chat.contactValue);
+  return `${name} · ${contact}`;
+}
 
-  const selectedChat = initialChats.find((c) => c.id === selectedChatId);
-  const initialMessages = selectedChatId ? (chatMessages[selectedChatId] ?? []) : [];
+export function ChatList({ initialChats, userId }: ChatListProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(initialChats[0]?.id ?? null);
+  const [detailsCache, setDetailsCache] = useState<Record<number, ChatDetails>>({});
+  const [loading, setLoading] = useState(false);
+
+  const loadChat = useCallback(
+    async (chatId: number) => {
+      if (detailsCache[chatId]) return;
+      setLoading(true);
+      try {
+        const details = await chatService.chatDetails(chatId);
+        setDetailsCache((prev) => ({ ...prev, [chatId]: details }));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [detailsCache],
+  );
+
+  useEffect(() => {
+    if (selectedId != null) loadChat(selectedId);
+  }, [selectedId, loadChat]);
+
+  const selectedChat = initialChats.find((c) => c.id === selectedId);
+  const selectedDetails = selectedId != null ? detailsCache[selectedId] : undefined;
 
   return (
-    <Wrapper>
-      <MainContainer style={{ width: '100%' }}>
-        <Sidebar position='left' style={{ minWidth: '240px', maxWidth: '300px' }}>
-          <ConversationList>
-            {initialChats.map((chat) => (
-              <Conversation
-                key={chat.id}
-                name={chat.senderName ?? `Чат #${chat.id}`}
-                info={
-                  chat.lastMessage
-                    ? lastMessageText(chat.lastMessage)
-                    : formatContact(chat.contactType, chat.contactValue)
-                }
-                active={chat.id === selectedChatId}
-                onClick={() => setSelectedChatId(chat.id)}
-              />
-            ))}
-          </ConversationList>
-        </Sidebar>
+    <Layout>
+      <SidebarPanel>
+        <SidebarHeader>Сообщения</SidebarHeader>
+        {initialChats.map((chat) => {
+          const active = chat.id === selectedId;
+          return (
+            <ChatItem
+              key={chat.id}
+              $active={active}
+              onClick={() => setSelectedId(chat.id)}
+            >
+              <ChatItemName $active={active}>{chat.senderName ?? `Чат #${chat.id}`}</ChatItemName>
+              <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
+            </ChatItem>
+          );
+        })}
+      </SidebarPanel>
 
+      <MainArea>
         {selectedChat ? (
           <ChatWindow
             chatId={selectedChat.id}
-            initialMessages={initialMessages}
+            initialMessages={selectedDetails?.messages ?? []}
             currentUserId={userId}
             isOwner
-            title={
-              selectedChat.senderName ??
-              `Чат #${selectedChat.id}` +
-                (selectedChat.contactType
-                  ? ' · ' + formatContact(selectedChat.contactType, selectedChat.contactValue)
-                  : '')
-            }
+            title={chatTitle(selectedChat)}
           />
         ) : (
           <EmptyState>Выберите чат</EmptyState>
         )}
-      </MainContainer>
-    </Wrapper>
+        {loading && !selectedDetails && (
+          <EmptyState style={{ position: 'absolute', inset: 0, background: 'transparent' }}>
+            Загрузка...
+          </EmptyState>
+        )}
+      </MainArea>
+    </Layout>
   );
 }

--- a/packages/web/src/components/Chat/ChatWindow.tsx
+++ b/packages/web/src/components/Chat/ChatWindow.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  ChatContainer,
+  ConversationHeader,
+  MainContainer,
+  Message,
+  MessageInput,
+  MessageList,
+} from '@chatscope/chat-ui-kit-react';
+import '@chatscope/chat-ui-kit-styles/dist/cjs/styles.min.css';
+import styled from 'styled-components';
+
+import { useChat } from '@/hooks/useChat';
+import { ChatContactBody, ChatDetails, ChatMessageInfo, MessageSource } from '@shared/chat/chat.types';
+import { themeable } from '@/themes/utils';
+import { fileService, chatService } from '@/services';
+import { FileFolder } from '@shared/file/file.types';
+
+const Wrapper = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  /* Override chatscope CSS vars with site theme */
+  --cs-conversation-header-background: ${themeable('secondaryBackground')};
+  --cs-conversation-header-color: ${themeable('textColor')};
+
+  .cs-main-container,
+  .cs-chat-container {
+    background: ${themeable('mainBackgroundColor')};
+    color: ${themeable('textColor')};
+    border: none;
+  }
+
+  .cs-message-list {
+    background: ${themeable('mainBackgroundColor')};
+  }
+
+  .cs-message__content {
+    background: ${themeable('secondaryBackground')};
+    color: ${themeable('textColor')};
+  }
+
+  .cs-message--outgoing .cs-message__content {
+    background: ${themeable('primaryColor')};
+    color: #fff;
+  }
+
+  .cs-message-input {
+    background: ${themeable('mainBackgroundColor')};
+    border-top: 1px solid ${themeable('secondaryBackground')};
+  }
+
+  .cs-message-input__content-editor-wrapper,
+  .cs-message-input__content-editor {
+    background: ${themeable('input.background')};
+    color: ${themeable('textColor')};
+  }
+
+  .cs-conversation-header {
+    background: ${themeable('secondaryBackground')};
+    color: ${themeable('textColor')};
+  }
+`;
+
+const ContactPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 16px;
+  background: ${themeable('secondaryBackground')};
+  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+  font-size: 13px;
+  color: ${themeable('textColor')};
+`;
+
+const ContactRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+const ContactSelect = styled.select`
+  background: ${themeable('input.background')};
+  color: ${themeable('textColor')};
+  border: 1px solid ${themeable('primaryColor')};
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 13px;
+  cursor: pointer;
+`;
+
+const ContactInput = styled.input`
+  background: ${themeable('input.background')};
+  color: ${themeable('textColor')};
+  border: 1px solid ${themeable('primaryColor')};
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 13px;
+  flex: 1;
+  min-width: 160px;
+`;
+
+const AttachButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px 8px;
+  color: ${themeable('primaryColor')};
+  font-size: 20px;
+  line-height: 1;
+  opacity: 0.8;
+  &:hover { opacity: 1; }
+`;
+
+const AttachmentImg = styled.img`
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 8px;
+  display: block;
+`;
+
+interface ChatWindowProps {
+  chatId: number;
+  initialMessages: ChatMessageInfo[];
+  currentUserId?: number;
+  isOwner?: boolean;
+  title?: string;
+  initialContact?: Pick<ChatDetails, 'contactType' | 'contactValue'>;
+}
+
+const CONTACT_OPTIONS = [
+  { value: 'none', label: 'Без ответа' },
+  { value: 'bot', label: 'Анонимно через бот' },
+  { value: 'tel', label: 'По телефону' },
+  { value: 'email', label: 'На e-mail' },
+];
+
+export function ChatWindow({
+  chatId,
+  initialMessages,
+  currentUserId,
+  isOwner = false,
+  title,
+  initialContact,
+}: ChatWindowProps) {
+  const { messages, connected, sendMessage } = useChat({ chatId, initialMessages });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const [contactType, setContactType] = useState(initialContact?.contactType ?? 'none');
+  const [contactValue, setContactValue] = useState(initialContact?.contactValue ?? '');
+
+  const handleContactChange = useCallback(
+    async (type: string, value: string) => {
+      setContactType(type);
+      setContactValue(value);
+      const body: ChatContactBody = { contactType: type, contactValue: value || undefined };
+      await chatService.updateContact(body, chatId).catch(() => {});
+    },
+    [chatId],
+  );
+
+  const handleSend = useCallback(
+    (text: string) => {
+      if (text.trim()) sendMessage(text.trim());
+    },
+    [sendMessage],
+  );
+
+  const handleAttach = useCallback(async () => {
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      const result = await fileService.upload(form, FileFolder.Chat);
+      sendMessage('', result.url);
+    } catch {
+      // ignore upload errors
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }, [sendMessage]);
+
+  const needsContactValue = contactType === 'tel' || contactType === 'email';
+
+  return (
+    <Wrapper>
+      {!isOwner && (
+        <ContactPanel>
+          <ContactRow>
+            <span>Способ связи:</span>
+            <ContactSelect
+              value={contactType}
+              onChange={(e) => handleContactChange(e.target.value, contactValue)}
+            >
+              {CONTACT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </ContactSelect>
+            {needsContactValue && (
+              <ContactInput
+                type={contactType === 'email' ? 'email' : 'tel'}
+                placeholder={contactType === 'email' ? 'your@email.com' : '+7...'}
+                value={contactValue}
+                onChange={(e) => setContactValue(e.target.value)}
+                onBlur={() => handleContactChange(contactType, contactValue)}
+              />
+            )}
+          </ContactRow>
+        </ContactPanel>
+      )}
+
+      <MainContainer style={{ flex: 1, minHeight: 0 }}>
+        <ChatContainer>
+          {title && (
+            <ConversationHeader>
+              <ConversationHeader.Content userName={title} />
+            </ConversationHeader>
+          )}
+          <MessageList>
+            {messages.map((msg) => {
+              const direction =
+                (msg.source === MessageSource.Sender) !== isOwner
+                  ? 'incoming'
+                  : 'outgoing';
+
+              if (msg.attachmentUrl) {
+                return (
+                  <Message
+                    key={msg.id}
+                    model={{ direction, position: 'single' }}
+                  >
+                    <Message.CustomContent>
+                      <AttachmentImg src={msg.attachmentUrl} alt='attachment' />
+                      {msg.text && <div>{msg.text}</div>}
+                    </Message.CustomContent>
+                  </Message>
+                );
+              }
+
+              return (
+                <Message
+                  key={msg.id}
+                  model={{
+                    message: msg.text,
+                    direction,
+                    position: 'single',
+                    sentTime: msg.createdAt,
+                  }}
+                />
+              );
+            })}
+          </MessageList>
+          <MessageInput
+            placeholder={connected ? 'Сообщение...' : 'Соединение...'}
+            onSend={handleSend}
+            disabled={!connected || uploading}
+            attachButton={false}
+            sendButton
+          >
+            <AttachButton
+              as='label'
+              title='Прикрепить изображение'
+              style={{ cursor: 'pointer' }}
+            >
+              📎
+              <input
+                ref={fileInputRef}
+                type='file'
+                accept='image/*'
+                style={{ display: 'none' }}
+                onChange={handleAttach}
+              />
+            </AttachButton>
+          </MessageInput>
+        </ChatContainer>
+      </MainContainer>
+    </Wrapper>
+  );
+}

--- a/packages/web/src/components/Navigation/Navigation.tsx
+++ b/packages/web/src/components/Navigation/Navigation.tsx
@@ -75,7 +75,8 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
 
   const menuItems = [
     { name: 'Мои авто', href: '/', requiresAuth: true },
-    { name: 'Добавить авто', href: '/car/new', requiresAuth: true }
+    { name: 'Добавить авто', href: '/car/new', requiresAuth: true },
+    { name: 'Сообщения', href: '/messages', requiresAuth: true }
   ];
 
   const filteredMenuItems = menuItems;

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { CHAT_EVENTS, ChatMessageInfo } from '@shared/chat/chat.types';
+import { getStoredAuthToken } from '@/utils/auth-storage';
+import { BACKEND_URL } from '@/utils/api-service';
+
+interface UseChatOptions {
+  chatId: number;
+  initialMessages?: ChatMessageInfo[];
+}
+
+export function useChat({ chatId, initialMessages = [] }: UseChatOptions) {
+  const [messages, setMessages] = useState<ChatMessageInfo[]>(initialMessages);
+  const [connected, setConnected] = useState(false);
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    const token = getStoredAuthToken();
+
+    const socketUrl = BACKEND_URL.startsWith('/') ? '' : BACKEND_URL;
+
+    const socket = io(`${socketUrl}/chat`, {
+      path: BACKEND_URL.startsWith('/') ? `${BACKEND_URL}/socket.io` : '/socket.io',
+      auth: token ? { token } : undefined,
+      withCredentials: true,
+    });
+
+    socketRef.current = socket;
+
+    socket.on('connect', () => {
+      setConnected(true);
+      socket.emit(CHAT_EVENTS.JOIN_CHAT, chatId);
+    });
+
+    socket.on('disconnect', () => setConnected(false));
+
+    socket.on(CHAT_EVENTS.NEW_MESSAGE, (msg: ChatMessageInfo) => {
+      setMessages((prev) => {
+        if (prev.some((m) => m.id === msg.id)) return prev;
+        return [...prev, msg];
+      });
+    });
+
+    return () => {
+      socket.emit(CHAT_EVENTS.LEAVE_CHAT, chatId);
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [chatId]);
+
+  const sendMessage = useCallback(
+    (text: string, attachmentUrl?: string) => {
+      socketRef.current?.emit(CHAT_EVENTS.SEND_MESSAGE, {
+        chatId,
+        text,
+        attachmentUrl,
+      });
+    },
+    [chatId],
+  );
+
+  return { messages, connected, sendMessage };
+}

--- a/packages/web/src/services/index.ts
+++ b/packages/web/src/services/index.ts
@@ -4,6 +4,7 @@ import CAR_API from '@shared/car/car.api';
 import FILE_API from '@shared/file/file.api';
 import { USER_API } from '@shared/user/user.api';
 import NOTIFICATION_API from '@shared/notification/notification.api';
+import CHAT_API from '@shared/chat/chat.api';
 
 export const createApi = (userToken?: string) => {
   return {
@@ -11,7 +12,8 @@ export const createApi = (userToken?: string) => {
     car: createApiService(CAR_API, userToken),
     file: createApiService(FILE_API, userToken),
     user: createApiService(USER_API, userToken),
-    notification: createApiService(NOTIFICATION_API, userToken)
+    notification: createApiService(NOTIFICATION_API, userToken),
+    chat: createApiService(CHAT_API, userToken)
   };
 };
 
@@ -22,3 +24,4 @@ export const carService = api.car;
 export const fileService = api.file;
 export const userService = api.user;
 export const notificationService = api.notification;
+export const chatService = api.chat;


### PR DESCRIPTION
## Summary

- **Bug fix**: chat messages were never loaded when selecting a chat in the sidebar — now fetches `chatDetails` on click with a per-chat cache so subsequent clicks don't re-fetch
- **Visual**: replaced chatscope `ConversationList` with a custom styled sidebar — properly themed with `secondaryBackground`, active item highlighted in `primaryColor` (#718EBF), name + preview text ellipsis, "Сообщения" header
- **Bug fix**: title concatenation operator precedence fixed

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_