### PR TITLE
fix: load chat messages on selection, custom sidebar, IoAdapter for Socket.io

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { IoAdapter } from '@nestjs/platform-socket.io';
 
 import { AppModule } from './app.module';
 import { ASSETS_FILE_PATH, ASSETS_URI_PATH } from './constants';
@@ -53,6 +54,8 @@ async function bootstrap() {
     console.info(`Global route prefix: ${routePrefix}`);
     app.setGlobalPrefix(routePrefix);
   }
+
+  app.useWebSocketAdapter(new IoAdapter(app));
 
   app.useGlobalPipes(new ValidationPipe());
 

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -1,55 +1,75 @@
 'use client';
 
-import React, { useState } from 'react';
-import {
-  Conversation,
-  ConversationList,
-  MainContainer,
-  Sidebar
-} from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { ChatInfo, ChatMessageInfo } from '@shared/chat/chat.types';
+import { ChatDetails, ChatInfo } from '@shared/chat/chat.types';
 import { themeable } from '@/themes/utils';
+import { chatService } from '@/services';
 import { ChatWindow } from './ChatWindow';
 
-const Wrapper = styled.div`
+const Layout = styled.div`
   height: calc(100vh - 64px);
   display: flex;
+  overflow: hidden;
+`;
 
-  --cs-conversation-list-background: ${themeable('secondaryBackground')};
-  --cs-conversation-background: ${themeable('secondaryBackground')};
-  --cs-conversation-color: ${themeable('textColor')};
-  --cs-sidebar-background: ${themeable('secondaryBackground')};
+const SidebarPanel = styled.div`
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: ${themeable('secondaryBackground')};
+  border-right: 1px solid ${themeable('mainBackgroundColor')};
+  overflow-y: auto;
+`;
 
-  .cs-sidebar {
-    background: ${themeable('secondaryBackground')};
-    border-right: 1px solid ${themeable('mainBackgroundColor')};
+const SidebarHeader = styled.div`
+  padding: 16px;
+  font-size: 17px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+  flex-shrink: 0;
+`;
+
+const ChatItem = styled.div<{ $active?: boolean }>`
+  padding: 12px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+  background: ${({ $active }) => ($active ? themeable('primaryColor') : 'transparent')};
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${({ $active }) =>
+      $active ? themeable('primaryColor') : themeable('mainBackgroundColor')};
   }
+`;
 
-  .cs-conversation-list {
-    background: ${themeable('secondaryBackground')};
-  }
+const ChatItemName = styled.div<{ $active?: boolean }>`
+  font-size: 14px;
+  font-weight: 600;
+  color: ${({ $active }) => ($active ? '#fff' : themeable('textColor'))};
+  margin-bottom: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
-  .cs-conversation {
-    background: ${themeable('secondaryBackground')};
-    color: ${themeable('textColor')};
+const ChatItemPreview = styled.div<{ $active?: boolean }>`
+  font-size: 12px;
+  color: ${({ $active }) => ($active ? 'rgba(255,255,255,0.75)' : themeable('textColor'))};
+  opacity: ${({ $active }) => ($active ? 1 : 0.55)};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
-    &:hover,
-    &[data-active='true'] {
-      background: ${themeable('mainBackgroundColor')};
-    }
-  }
-
-  .cs-conversation__name {
-    color: ${themeable('textColor')};
-  }
-
-  .cs-conversation__info {
-    color: ${themeable('textColor')};
-    opacity: 0.6;
-  }
+const MainArea = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 `;
 
 const EmptyState = styled.div`
@@ -58,8 +78,9 @@ const EmptyState = styled.div`
   align-items: center;
   justify-content: center;
   color: ${themeable('textColor')};
-  opacity: 0.5;
+  opacity: 0.4;
   font-size: 15px;
+  background: ${themeable('mainBackgroundColor')};
 `;
 
 interface ChatListProps {
@@ -74,56 +95,78 @@ function formatContact(contactType?: string | null, contactValue?: string | null
   return 'Анонимно';
 }
 
-function lastMessageText(msg?: ChatMessageInfo): string {
-  if (!msg) return '';
+function previewText(chat: ChatInfo): string {
+  const msg = chat.lastMessage;
+  if (!msg) return formatContact(chat.contactType, chat.contactValue);
   if (msg.attachmentUrl && !msg.text) return '📎 Изображение';
   return msg.text ?? '';
 }
 
+function chatTitle(chat: ChatInfo): string {
+  const name = chat.senderName ?? `Чат #${chat.id}`;
+  const contact = formatContact(chat.contactType, chat.contactValue);
+  return `${name} · ${contact}`;
+}
+
 export function ChatList({ initialChats, userId }: ChatListProps) {
-  const [selectedChatId, setSelectedChatId] = useState<number | null>(initialChats[0]?.id ?? null);
-  const selectedChat = initialChats.find(c => c.id === selectedChatId);
-  const initialMessages: ChatMessageInfo[] = [];
+  const [selectedId, setSelectedId] = useState<number | null>(initialChats[0]?.id ?? null);
+  const [detailsCache, setDetailsCache] = useState<Record<number, ChatDetails>>({});
+  const [loading, setLoading] = useState(false);
+
+  const loadChat = useCallback(
+    async (chatId: number) => {
+      if (detailsCache[chatId]) return;
+      setLoading(true);
+      try {
+        const details = await chatService.chatDetails(chatId);
+        setDetailsCache(prev => ({ ...prev, [chatId]: details }));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [detailsCache]
+  );
+
+  useEffect(() => {
+    if (selectedId != null) loadChat(selectedId);
+  }, [selectedId, loadChat]);
+
+  const selectedChat = initialChats.find(c => c.id === selectedId);
+  const selectedDetails = selectedId != null ? detailsCache[selectedId] : undefined;
 
   return (
-    <Wrapper>
-      <MainContainer style={{ width: '100%' }}>
-        <Sidebar position='left' style={{ minWidth: '240px', maxWidth: '300px' }}>
-          <ConversationList>
-            {initialChats.map(chat => (
-              <Conversation
-                key={chat.id}
-                name={chat.senderName ?? `Чат #${chat.id}`}
-                info={
-                  chat.lastMessage
-                    ? lastMessageText(chat.lastMessage)
-                    : formatContact(chat.contactType, chat.contactValue)
-                }
-                active={chat.id === selectedChatId}
-                onClick={() => setSelectedChatId(chat.id)}
-              />
-            ))}
-          </ConversationList>
-        </Sidebar>
+    <Layout>
+      <SidebarPanel>
+        <SidebarHeader>Сообщения</SidebarHeader>
+        {initialChats.map(chat => {
+          const active = chat.id === selectedId;
+          return (
+            <ChatItem key={chat.id} $active={active} onClick={() => setSelectedId(chat.id)}>
+              <ChatItemName $active={active}>{chat.senderName ?? `Чат #${chat.id}`}</ChatItemName>
+              <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
+            </ChatItem>
+          );
+        })}
+      </SidebarPanel>
 
+      <MainArea>
         {selectedChat ? (
           <ChatWindow
             chatId={selectedChat.id}
-            initialMessages={initialMessages}
+            initialMessages={selectedDetails?.messages ?? []}
             currentUserId={userId}
             isOwner
-            title={
-              selectedChat.senderName ??
-              `Чат #${selectedChat.id}` +
-                (selectedChat.contactType
-                  ? ' · ' + formatContact(selectedChat.contactType, selectedChat.contactValue)
-                  : '')
-            }
+            title={chatTitle(selectedChat)}
           />
         ) : (
           <EmptyState>Выберите чат</EmptyState>
         )}
-      </MainContainer>
-    </Wrapper>
+        {loading && !selectedDetails && (
+          <EmptyState style={{ position: 'absolute', inset: 0, background: 'transparent' }}>
+            Загрузка...
+          </EmptyState>
+        )}
+      </MainArea>
+    </Layout>
   );
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `ChatList` — messages were never loaded when selecting a chat; now fetches `chatDetails` on click with a per-chat cache
- **Visual**: replaced chatscope `ConversationList` with a fully custom styled sidebar (themed, active item in `primaryColor`, ellipsis overflow)
- **Bug fix**: `main.ts` — register `IoAdapter` from `@nestjs/platform-socket.io` so the backend actually serves the `/socket.io` endpoint (was returning 404 before)

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_