### PR TITLE
fix: create anonymous_id cookie on first chat visit so messages can be sent

### DIFF
--- a/packages/backend/src/app/chat/chat.controller.ts
+++ b/packages/backend/src/app/chat/chat.controller.ts
@@ -6,19 +6,17 @@ import {
   ParseIntPipe,
   Post,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { ChatService } from './chat.service';
 import { JwtAuthGuard, OptionalJwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../users/user.decorator';
 import { RequestUser } from '@paulislava/shared/user/user.types';
-import CHAT_API, {
-  CHAT_CODE_PARAM,
-  CHAT_ID_PARAM,
-} from '@paulislava/shared/chat/chat.api';
+import CHAT_API, { CHAT_CODE_PARAM, CHAT_ID_PARAM } from '@paulislava/shared/chat/chat.api';
 import {
   ChatContactBody,
   ChatDetails,
@@ -74,13 +72,32 @@ export class ChatController {
 
   @Get(CHAT_API.backendRoutes.chatByCarCode)
   @UseGuards(OptionalJwtAuthGuard)
-  chatByCarCode(
+  async chatByCarCode(
     @Param(CHAT_CODE_PARAM) code: string,
     @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
     @CurrentUser(true) user?: RequestUser,
   ): Promise<ChatDetails> {
-    const anonymousId =
-      req.cookies?.[this.configService.auth.anonymousIdCookie];
+    const cookieName = this.configService.auth.anonymousIdCookie;
+    let anonymousId: string | undefined = req.cookies?.[cookieName];
+
+    if (!anonymousId && !user) {
+      const ip = req.ip ?? '';
+      const ua = (req.headers['user-agent'] as string) ?? '';
+      anonymousId = await this.chatService.getOrCreateAnonymousId(undefined, undefined, ip, ua);
+      if (anonymousId) {
+        const expires = new Date();
+        expires.setDate(expires.getDate() + 10000);
+        res.cookie(cookieName, anonymousId, {
+          expires,
+          httpOnly: true,
+          secure: true,
+          sameSite: 'none',
+          path: '/',
+        });
+      }
+    }
+
     return this.chatService.getChatByCarCode(code, user?.userId, anonymousId);
   }
 
@@ -91,12 +108,7 @@ export class ChatController {
     @Param(CHAT_ID_PARAM, ParseIntPipe) chatId: number,
     @CurrentUser() user: RequestUser,
   ): Promise<ChatMessageInfo> {
-    return this.chatService.sendOwnerMessage(
-      chatId,
-      body.text,
-      body.attachmentUrl,
-      user.userId,
-    );
+    return this.chatService.sendOwnerMessage(chatId, body.text, body.attachmentUrl, user.userId);
   }
 
   @Post(CHAT_API.backendRoutes.updateContact)
@@ -107,13 +119,7 @@ export class ChatController {
     @Req() req: Request,
     @CurrentUser(true) user?: RequestUser,
   ): Promise<void> {
-    const anonymousId =
-      req.cookies?.[this.configService.auth.anonymousIdCookie];
-    return this.chatService.updateContact(
-      chatId,
-      body,
-      user?.userId,
-      anonymousId,
-    );
+    const anonymousId = req.cookies?.[this.configService.auth.anonymousIdCookie];
+    return this.chatService.updateContact(chatId, body, user?.userId, anonymousId);
   }
 }

--- a/packages/backend/src/app/chat/chat.service.ts
+++ b/packages/backend/src/app/chat/chat.service.ts
@@ -239,19 +239,19 @@ export class ChatService {
     });
   }
 
-  private async getOrCreateAnonymousId(
+  async getOrCreateAnonymousId(
     anonymousId: string | undefined,
     userId: number | undefined,
-    ip: string,
-    userAgent: string,
+    ip?: string,
+    userAgent?: string,
   ): Promise<string | undefined> {
     if (anonymousId || userId) {
       return anonymousId;
     }
 
     const newAnonymousUser = await this.anonymousUserRepository.save({
-      ip,
-      userAgent,
+      ip: ip ?? '',
+      userAgent: userAgent ?? '',
     });
 
     return newAnonymousUser.id;


### PR DESCRIPTION
## Root cause

When an anonymous user visited `/g/[code]/chat` for the first time (no `anonymous_id` cookie), `chatByCarCode` created a chat with `anonymousSender = null`. Later when they tried to send a WebSocket message, `handleWebSocketMessage` checked `chat.anonymousSender?.id === anonymousId` — both `undefined` — and threw `ForbiddenException('Access denied')`. The error was emitted back to the client but nobody listened, so the message silently disappeared.

## Fix

- `chatByCarCode` controller: if no `anonymous_id` cookie and user is not authenticated, call `getOrCreateAnonymousId` and set the cookie in the response (same options as the old `sendMessage` flow)
- `getOrCreateAnonymousId` in service: changed from `private` to public so the controller can call it; made `ip`/`userAgent` params optional (with `''` defaults) to avoid TypeScript errors

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_