### PR TITLE
feat: Telegram-style chat UI, mobile sidebar toggle, desktop resize

### DIFF
--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { ChatDetails, ChatInfo } from '@shared/chat/chat.types';
@@ -8,29 +8,89 @@ import { themeable } from '@/themes/utils';
 import { chatService } from '@/services';
 import { ChatWindow } from './ChatWindow';
 
+const SIDEBAR_DEFAULT = 280;
+const SIDEBAR_MIN = 180;
+const SIDEBAR_MAX = 520;
+const MOBILE_BP = 640;
+
 const Layout = styled.div`
   height: calc(100vh - 64px);
   display: flex;
   overflow: hidden;
+  position: relative;
 `;
 
-const SidebarPanel = styled.div`
-  width: 280px;
+const SidebarPanel = styled.div<{ $open: boolean; $width: number }>`
+  width: ${({ $open, $width }) => ($open ? `${$width}px` : '0')};
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   background: ${themeable('secondaryBackground')};
   border-right: 1px solid ${themeable('mainBackgroundColor')};
-  overflow-y: auto;
+  overflow: hidden;
+  transition: width 0.25s ease;
+
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    z-index: 10;
+    width: ${({ $open }) => ($open ? 'min(85vw, 320px)' : '0')} !important;
+    box-shadow: ${({ $open }) => ($open ? '4px 0 20px rgba(0,0,0,0.22)' : 'none')};
+    transition:
+      width 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+      box-shadow 0.28s ease;
+  }
+`;
+
+const SidebarInner = styled.div`
+  width: ${SIDEBAR_DEFAULT}px;
+  min-width: ${SIDEBAR_MIN}px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    width: min(85vw, 320px);
+    min-width: unset;
+  }
 `;
 
 const SidebarHeader = styled.div`
-  padding: 16px;
+  padding: 14px 16px;
   font-size: 17px;
   font-weight: 600;
   color: ${themeable('textColor')};
   border-bottom: 1px solid ${themeable('mainBackgroundColor')};
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const IconBtn = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: ${themeable('textColor')};
+  padding: 4px 6px;
+  border-radius: 6px;
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  opacity: 0.65;
+  &:hover {
+    background: ${themeable('mainBackgroundColor')};
+    opacity: 1;
+  }
+`;
+
+const SidebarScroll = styled.div`
+  overflow-y: auto;
+  flex: 1;
 `;
 
 const ChatItem = styled.div<{ $active?: boolean }>`
@@ -65,11 +125,61 @@ const ChatItemPreview = styled.div<{ $active?: boolean }>`
   text-overflow: ellipsis;
 `;
 
+const ResizeHandle = styled.div`
+  width: 5px;
+  cursor: col-resize;
+  flex-shrink: 0;
+  background: transparent;
+  transition: background 0.15s;
+  &:hover,
+  &:active {
+    background: ${themeable('primaryColor')};
+    opacity: 0.45;
+  }
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    display: none;
+  }
+`;
+
+const MobileOverlay = styled.div`
+  display: none;
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    display: block;
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.38);
+    z-index: 9;
+  }
+`;
+
 const MainArea = styled.div`
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
+`;
+
+const MobileBar = styled.div`
+  display: none;
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: ${themeable('secondaryBackground')};
+    border-bottom: 1px solid ${themeable('mainBackgroundColor')};
+    flex-shrink: 0;
+  }
+`;
+
+const MobileBarTitle = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 `;
 
 const EmptyState = styled.div`
@@ -112,6 +222,53 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
   const [selectedId, setSelectedId] = useState<number | null>(initialChats[0]?.id ?? null);
   const [detailsCache, setDetailsCache] = useState<Record<number, ChatDetails>>({});
   const [loading, setLoading] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const isResizingRef = useRef(false);
+  const dragStartXRef = useRef(0);
+  const dragStartWidthRef = useRef(0);
+
+  // Detect mobile and set initial sidebar state
+  useEffect(() => {
+    const check = () => {
+      const mobile = window.innerWidth < MOBILE_BP;
+      setIsMobile(mobile);
+      setSidebarOpen(!mobile);
+    };
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  // Desktop resize drag
+  const startResize = useCallback(
+    (e: React.MouseEvent) => {
+      isResizingRef.current = true;
+      dragStartXRef.current = e.clientX;
+      dragStartWidthRef.current = sidebarWidth;
+      e.preventDefault();
+    },
+    [sidebarWidth]
+  );
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!isResizingRef.current) return;
+      const next = dragStartWidthRef.current + (e.clientX - dragStartXRef.current);
+      setSidebarWidth(Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, next)));
+    };
+    const onUp = () => {
+      isResizingRef.current = false;
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, []);
 
   const loadChat = useCallback(
     async (chatId: number) => {
@@ -131,25 +288,55 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
     if (selectedId != null) loadChat(selectedId);
   }, [selectedId, loadChat]);
 
+  const handleSelectChat = useCallback(
+    (chatId: number) => {
+      setSelectedId(chatId);
+      if (isMobile) setSidebarOpen(false);
+    },
+    [isMobile]
+  );
+
   const selectedChat = initialChats.find(c => c.id === selectedId);
   const selectedDetails = selectedId != null ? detailsCache[selectedId] : undefined;
 
   return (
     <Layout>
-      <SidebarPanel>
-        <SidebarHeader>Сообщения</SidebarHeader>
-        {initialChats.map(chat => {
-          const active = chat.id === selectedId;
-          return (
-            <ChatItem key={chat.id} $active={active} onClick={() => setSelectedId(chat.id)}>
-              <ChatItemName $active={active}>{chat.senderName ?? `Чат #${chat.id}`}</ChatItemName>
-              <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
-            </ChatItem>
-          );
-        })}
+      {isMobile && sidebarOpen && <MobileOverlay onClick={() => setSidebarOpen(false)} />}
+
+      <SidebarPanel $open={sidebarOpen} $width={sidebarWidth}>
+        <SidebarInner>
+          <SidebarHeader>
+            Сообщения
+            <IconBtn onClick={() => setSidebarOpen(false)} title='Закрыть'>
+              ✕
+            </IconBtn>
+          </SidebarHeader>
+          <SidebarScroll>
+            {initialChats.map(chat => {
+              const active = chat.id === selectedId;
+              return (
+                <ChatItem key={chat.id} $active={active} onClick={() => handleSelectChat(chat.id)}>
+                  <ChatItemName $active={active}>
+                    {chat.senderName ?? `Чат #${chat.id}`}
+                  </ChatItemName>
+                  <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
+                </ChatItem>
+              );
+            })}
+          </SidebarScroll>
+        </SidebarInner>
       </SidebarPanel>
 
+      {!isMobile && <ResizeHandle onMouseDown={startResize} />}
+
       <MainArea>
+        <MobileBar>
+          <IconBtn onClick={() => setSidebarOpen(v => !v)} title='Список чатов'>
+            ☰
+          </IconBtn>
+          <MobileBarTitle>{selectedChat ? chatTitle(selectedChat) : 'Сообщения'}</MobileBarTitle>
+        </MobileBar>
+
         {selectedChat && selectedDetails ? (
           <ChatWindow
             key={selectedId}

--- a/packages/web/src/components/Chat/ChatWindow.tsx
+++ b/packages/web/src/components/Chat/ChatWindow.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import React, { useCallback, useRef, useState } from 'react';
-import {
-  ChatContainer,
-  ConversationHeader,
-  MainContainer,
-  Message,
-  MessageInput,
-  MessageList
-} from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { useChat } from '@/hooks/useChat';
@@ -20,101 +11,224 @@ import {
   MessageSource
 } from '@shared/chat/chat.types';
 import { themeable } from '@/themes/utils';
-import { fileService, chatService } from '@/services';
+import { chatService, fileService } from '@/services';
 import { FileFolder } from '@shared/file/file.types';
+
+// ─── Layout ──────────────────────────────────────────────────────────────────
 
 const Wrapper = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-
-  /* Override chatscope CSS vars with site theme */
-  --cs-conversation-header-background: ${themeable('secondaryBackground')};
-  --cs-conversation-header-color: ${themeable('textColor')};
-
-  .cs-main-container,
-  .cs-chat-container {
-    background: ${themeable('mainBackgroundColor')};
-    color: ${themeable('textColor')};
-    border: none;
-  }
-
-  .cs-message-list {
-    background: ${themeable('mainBackgroundColor')};
-  }
-
-  .cs-message__content {
-    background: ${themeable('secondaryBackground')};
-    color: ${themeable('textColor')};
-  }
-
-  .cs-message--outgoing .cs-message__content {
-    background: ${themeable('primaryColor')};
-    color: #fff;
-  }
-
-  .cs-message-input {
-    background: ${themeable('mainBackgroundColor')};
-    border-top: 1px solid ${themeable('secondaryBackground')};
-  }
-
-  .cs-message-input__content-editor-wrapper,
-  .cs-message-input__content-editor {
-    background: ${themeable('input.background')};
-    color: ${themeable('textColor')};
-  }
-
-  .cs-conversation-header {
-    background: ${themeable('secondaryBackground')};
-    color: ${themeable('textColor')};
-  }
+  background: ${themeable('mainBackgroundColor')};
+  overflow: hidden;
 `;
 
-const ContactPanel = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 16px;
-  background: ${themeable('secondaryBackground')};
-  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
-  font-size: 13px;
-  color: ${themeable('textColor')};
-`;
+// ─── Header ──────────────────────────────────────────────────────────────────
 
-const ContactRow = styled.div`
+const Header = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
+  padding: 0 16px;
+  min-height: 52px;
+  flex-shrink: 0;
+  background: ${themeable('secondaryBackground')};
+  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+`;
+
+const HeaderTitle = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const HeaderName = styled.div`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const HeaderStatus = styled.div<{ $online: boolean }>`
+  font-size: 12px;
+  color: ${({ $online }) => ($online ? '#4cd964' : themeable('textColor'))};
+  opacity: ${({ $online }) => ($online ? 1 : 0.45)};
+  margin-top: 1px;
+`;
+
+// ─── Message list ─────────────────────────────────────────────────────────────
+
+const MsgList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+`;
+
+const MsgRow = styled.div<{ $out: boolean }>`
+  display: flex;
+  justify-content: ${({ $out }) => ($out ? 'flex-end' : 'flex-start')};
+`;
+
+const Bubble = styled.div<{ $out: boolean }>`
+  max-width: 75%;
+  padding: 8px 12px 6px;
+  border-radius: ${({ $out }) => ($out ? '18px 18px 4px 18px' : '18px 18px 18px 4px')};
+  background: ${({ $out }) =>
+    $out ? 'var(--cs-bubble-out, #2b82e5)' : themeable('secondaryBackground')};
+  color: ${({ $out }) => ($out ? '#fff' : themeable('textColor'))};
+  font-size: 14px;
+  line-height: 1.45;
+  word-break: break-word;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.14);
+  position: relative;
+`;
+
+const BubbleText = styled.span`
+  display: block;
+  padding-right: 44px;
+`;
+
+const BubbleTime = styled.span<{ $out: boolean }>`
+  font-size: 11px;
+  opacity: 0.65;
+  position: absolute;
+  bottom: 6px;
+  right: 10px;
+  color: ${({ $out }) => ($out ? 'rgba(255,255,255,0.85)' : themeable('textColor'))};
+`;
+
+const AttachImg = styled.img`
+  max-width: 220px;
+  max-height: 220px;
+  border-radius: 12px;
+  display: block;
+  margin-bottom: 2px;
+`;
+
+// ─── Contact panel ────────────────────────────────────────────────────────────
+
+const ContactPanel = styled.div`
+  display: flex;
   flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: ${themeable('secondaryBackground')};
+  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
+  font-size: 13px;
+  color: ${themeable('textColor')};
+  flex-shrink: 0;
 `;
 
 const ContactSelect = styled.select`
-  background: ${themeable('input.background')};
+  background: ${themeable('mainBackgroundColor')};
   color: ${themeable('textColor')};
-  border: 1px solid ${themeable('primaryColor')};
-  border-radius: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 8px;
   padding: 4px 8px;
   font-size: 13px;
   cursor: pointer;
 `;
 
 const ContactInput = styled.input`
-  background: ${themeable('input.background')};
+  background: ${themeable('mainBackgroundColor')};
   color: ${themeable('textColor')};
-  border: 1px solid ${themeable('primaryColor')};
-  border-radius: 6px;
-  padding: 4px 8px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 8px;
+  padding: 4px 10px;
   font-size: 13px;
   flex: 1;
-  min-width: 160px;
+  min-width: 140px;
+  &::placeholder {
+    opacity: 0.45;
+  }
 `;
 
-const AttachmentImg = styled.img`
-  max-width: 200px;
-  max-height: 200px;
-  border-radius: 8px;
-  display: block;
+// ─── Input area ───────────────────────────────────────────────────────────────
+
+const InputArea = styled.div`
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 10px;
+  background: ${themeable('secondaryBackground')};
+  border-top: 1px solid rgba(128, 128, 128, 0.12);
+  flex-shrink: 0;
 `;
+
+const TextInput = styled.textarea`
+  flex: 1;
+  border: none;
+  outline: none;
+  background: ${themeable('mainBackgroundColor')};
+  color: ${themeable('textColor')};
+  font-size: 14px;
+  line-height: 1.45;
+  padding: 10px 14px;
+  border-radius: 22px;
+  resize: none;
+  max-height: 120px;
+  min-height: 42px;
+  font-family: inherit;
+
+  &::placeholder {
+    opacity: 0.4;
+  }
+`;
+
+const RoundBtn = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  color: ${themeable('primaryColor')};
+  font-size: 22px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${themeable('mainBackgroundColor')};
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+`;
+
+const SendBtn = styled(RoundBtn)<{ $active: boolean }>`
+  background: ${({ $active }) => ($active ? themeable('primaryColor') : 'transparent')};
+  color: ${({ $active }) => ($active ? '#fff' : themeable('primaryColor'))};
+
+  &:hover {
+    background: ${({ $active }) =>
+      $active ? themeable('primaryColor') : themeable('mainBackgroundColor')};
+  }
+`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+}
+
+const CONTACT_OPTIONS = [
+  { value: 'none', label: 'Без ответа' },
+  { value: 'bot', label: 'Анонимно через бот' },
+  { value: 'tel', label: 'По телефону' },
+  { value: 'email', label: 'На e-mail' }
+];
 
 interface ChatWindowProps {
   chatId: number;
@@ -125,12 +239,7 @@ interface ChatWindowProps {
   initialContact?: Pick<ChatDetails, 'contactType' | 'contactValue'>;
 }
 
-const CONTACT_OPTIONS = [
-  { value: 'none', label: 'Без ответа' },
-  { value: 'bot', label: 'Анонимно через бот' },
-  { value: 'tel', label: 'По телефону' },
-  { value: 'email', label: 'На e-mail' }
-];
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export function ChatWindow({
   chatId,
@@ -140,11 +249,19 @@ export function ChatWindow({
   initialContact
 }: ChatWindowProps) {
   const { messages, connected, sendMessage } = useChat({ chatId, initialMessages });
+  const listRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const textRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState('');
   const [uploading, setUploading] = useState(false);
-
   const [contactType, setContactType] = useState(initialContact?.contactType ?? 'none');
   const [contactValue, setContactValue] = useState(initialContact?.contactValue ?? '');
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
 
   const handleContactChange = useCallback(
     async (type: string, value: string) => {
@@ -156,17 +273,35 @@ export function ChatWindow({
     [chatId]
   );
 
-  const handleSend = useCallback(
-    (text: string) => {
-      if (text.trim()) sendMessage(text.trim());
+  const handleSend = useCallback(() => {
+    const t = text.trim();
+    if (!t || !connected) return;
+    sendMessage(t);
+    setText('');
+    if (textRef.current) {
+      textRef.current.style.height = 'auto';
+    }
+  }, [text, connected, sendMessage]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
     },
-    [sendMessage]
+    [handleSend]
   );
+
+  const handleTextChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+    e.target.style.height = 'auto';
+    e.target.style.height = `${Math.min(e.target.scrollHeight, 120)}px`;
+  }, []);
 
   const handleAttach = useCallback(async () => {
     const file = fileInputRef.current?.files?.[0];
     if (!file) return;
-
     setUploading(true);
     try {
       const form = new FormData();
@@ -174,97 +309,101 @@ export function ChatWindow({
       const result = await fileService.upload(form, FileFolder.Chat);
       sendMessage('', result.url);
     } catch {
-      // ignore upload errors
+      // ignore
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
   }, [sendMessage]);
 
-  const needsContactValue = contactType === 'tel' || contactType === 'email';
+  const needsValue = contactType === 'tel' || contactType === 'email';
 
   return (
     <Wrapper>
+      {title && (
+        <Header>
+          <HeaderTitle>
+            <HeaderName>{title}</HeaderName>
+            <HeaderStatus $online={connected}>
+              {connected ? 'в сети' : 'соединение...'}
+            </HeaderStatus>
+          </HeaderTitle>
+        </Header>
+      )}
+
       {!isOwner && (
         <ContactPanel>
-          <ContactRow>
-            <span>Способ связи:</span>
-            <ContactSelect
-              value={contactType}
-              onChange={e => handleContactChange(e.target.value, contactValue)}
-            >
-              {CONTACT_OPTIONS.map(o => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </ContactSelect>
-            {needsContactValue && (
-              <ContactInput
-                type={contactType === 'email' ? 'email' : 'tel'}
-                placeholder={contactType === 'email' ? 'your@email.com' : '+7...'}
-                value={contactValue}
-                onChange={e => setContactValue(e.target.value)}
-                onBlur={() => handleContactChange(contactType, contactValue)}
-              />
-            )}
-          </ContactRow>
+          <span style={{ opacity: 0.65 }}>Способ связи:</span>
+          <ContactSelect
+            value={contactType}
+            onChange={e => handleContactChange(e.target.value, contactValue)}
+          >
+            {CONTACT_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </ContactSelect>
+          {needsValue && (
+            <ContactInput
+              type={contactType === 'email' ? 'email' : 'tel'}
+              placeholder={contactType === 'email' ? 'your@email.com' : '+7...'}
+              value={contactValue}
+              onChange={e => setContactValue(e.target.value)}
+              onBlur={() => handleContactChange(contactType, contactValue)}
+            />
+          )}
         </ContactPanel>
       )}
 
-      <MainContainer style={{ flex: 1, minHeight: 0 }}>
-        <ChatContainer>
-          {title && (
-            <ConversationHeader>
-              <ConversationHeader.Content userName={title} />
-            </ConversationHeader>
-          )}
-          <MessageList>
-            {messages.map(msg => {
-              const direction =
-                (msg.source === MessageSource.Sender) !== isOwner ? 'incoming' : 'outgoing';
+      <MsgList ref={listRef}>
+        {messages.map(msg => {
+          const out = (msg.source === MessageSource.Sender) !== isOwner;
+          return (
+            <MsgRow key={msg.id} $out={out}>
+              <Bubble $out={out}>
+                {msg.attachmentUrl && <AttachImg src={msg.attachmentUrl} alt='attachment' />}
+                {msg.text && <BubbleText>{msg.text}</BubbleText>}
+                <BubbleTime $out={out}>{formatTime(msg.createdAt)}</BubbleTime>
+              </Bubble>
+            </MsgRow>
+          );
+        })}
+      </MsgList>
 
-              if (msg.attachmentUrl) {
-                return (
-                  <Message key={msg.id} model={{ direction, position: 'single' }}>
-                    <Message.CustomContent>
-                      <AttachmentImg src={msg.attachmentUrl} alt='attachment' />
-                      {msg.text && <div>{msg.text}</div>}
-                    </Message.CustomContent>
-                  </Message>
-                );
-              }
-
-              return (
-                <Message
-                  key={msg.id}
-                  model={{
-                    message: msg.text,
-                    direction,
-                    position: 'single',
-                    sentTime: msg.createdAt
-                  }}
-                />
-              );
-            })}
-          </MessageList>
-          <MessageInput
-            placeholder={connected ? 'Сообщение...' : 'Соединение...'}
-            onSend={handleSend}
-            disabled={!connected || uploading}
-            attachButton
-            onAttachClick={() => fileInputRef.current?.click()}
-            sendButton
-          />
-          <input
-            ref={fileInputRef}
-            type='file'
-            accept='image/*'
-            style={{ display: 'none' }}
-            onChange={handleAttach}
-          />
-        </ChatContainer>
-      </MainContainer>
+      <InputArea>
+        <RoundBtn
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          title='Прикрепить изображение'
+        >
+          📎
+        </RoundBtn>
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept='image/*'
+          style={{ display: 'none' }}
+          onChange={handleAttach}
+        />
+        <TextInput
+          ref={textRef}
+          rows={1}
+          placeholder={connected ? 'Сообщение...' : 'Соединение...'}
+          value={text}
+          onChange={handleTextChange}
+          onKeyDown={handleKeyDown}
+          disabled={!connected}
+        />
+        <SendBtn
+          $active={!!text.trim() && connected}
+          onClick={handleSend}
+          disabled={!text.trim() || !connected}
+          title='Отправить'
+        >
+          ➤
+        </SendBtn>
+      </InputArea>
     </Wrapper>
   );
 }


### PR DESCRIPTION
## Summary

- **ChatWindow**: полностью убран `@chatscope/chat-ui-kit-react`, заменён на кастомные styled-components в стиле Telegram
  - Пузыри с асимметричным `border-radius` (как в Telegram)
  - Время сообщения внутри пузыря (абсолютное позиционирование)
  - Заголовок чата через `themeable('secondaryBackground')` — исправлен белый бокс на тёмной теме
  - Зелёный индикатор онлайн (`#4cd964`)
  - Авто-растущий `<textarea>`, Enter отправляет, Shift+Enter — перенос
  - Авто-скролл к последнему сообщению

- **ChatList**: новый layout с адаптивным сайдбаром
  - Мобилка: сайдбар свёрнут по умолчанию, раскрывается по гамбургеру с анимацией `cubic-bezier(0.4, 0, 0.2, 1)` + тёмный оверлей
  - Десктоп: сайдбар можно тянуть за ручку (180–520px)

## Test plan

- [ ] Тёмная тема: заголовок чата не белый
- [ ] Сообщения отображаются в Telegram-стиле (пузыри с асимметричным радиусом, время внутри)
- [ ] Мобилка: сайдбар скрыт при загрузке, открывается по ☰ с анимацией, закрывается по оверлею
- [ ] Десктоп: граница сайдбара тянется мышью

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_