### PR TITLE
feat(chat): Telegram-style chat UX — ссылки, выделение, скелетон, назад

### DIFF
--- a/packages/web/src/app/messages/[chatId]/page.tsx
+++ b/packages/web/src/app/messages/[chatId]/page.tsx
@@ -1,0 +1,36 @@
+import { AuthComponent, withUser } from '@/context/Auth/withUser';
+import { createApi } from '@/services';
+import { AUTH_COOKIE_NAME } from '@/helpers/constants';
+import { cookies } from 'next/headers';
+import { ChatList } from '@/components/Chat/ChatList';
+import { ChatDetails } from '@shared/chat/chat.types';
+
+interface ChatPageProps {
+  params: Promise<{ chatId: string }>;
+}
+
+const ChatPage: AuthComponent<ChatPageProps> = async ({ user, params }) => {
+  const { chatId } = await params;
+  const chatIdNum = parseInt(chatId);
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+  const api = createApi(token);
+
+  const [chats, details] = await Promise.all([
+    api.chat.myChats().catch(() => []),
+    api.chat.chatDetails(chatIdNum).catch((): ChatDetails | null => null)
+  ]);
+
+  const initialChatDetails: Record<number, ChatDetails> = details ? { [chatIdNum]: details } : {};
+
+  return (
+    <ChatList
+      initialChats={chats}
+      userId={user.userId}
+      selectedChatId={chatIdNum}
+      initialChatDetails={initialChatDetails}
+    />
+  );
+};
+
+export default withUser(ChatPage, false);

--- a/packages/web/src/components/Chat/ChatList.tsx
+++ b/packages/web/src/components/Chat/ChatList.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { useRouter } from 'next/navigation';
 
 import { ChatDetails, ChatInfo } from '@shared/chat/chat.types';
 import { themeable } from '@/themes/utils';
@@ -9,10 +10,12 @@ import { chatService } from '@/services';
 import { ChatWindow } from './ChatWindow';
 import { useChatList } from '@/hooks/useChatList';
 
-const SIDEBAR_DEFAULT = 280;
-const SIDEBAR_MIN = 180;
+const SIDEBAR_DEFAULT = 300;
+const SIDEBAR_MIN = 220;
 const SIDEBAR_MAX = 520;
 const MOBILE_BP = 640;
+
+// ─── Layout ──────────────────────────────────────────────────────────────────
 
 const Layout = styled.div`
   flex: 1;
@@ -28,21 +31,15 @@ const SidebarPanel = styled.div<{ $open: boolean; $width: number }>`
   display: flex;
   flex-direction: column;
   background: ${themeable('secondaryBackground')};
-  border-right: 1px solid ${themeable('mainBackgroundColor')};
+  border-right: 1px solid rgba(128, 128, 128, 0.1);
   overflow: hidden;
   transition: width 0.25s ease;
 
   @media (max-width: ${MOBILE_BP - 1}px) {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    z-index: 10;
-    width: ${({ $open }) => ($open ? 'min(85vw, 320px)' : '0')} !important;
-    box-shadow: ${({ $open }) => ($open ? '4px 0 20px rgba(0,0,0,0.22)' : 'none')};
-    transition:
-      width 0.28s cubic-bezier(0.4, 0, 0.2, 1),
-      box-shadow 0.28s ease;
+    width: 100% !important;
+    flex-shrink: 1;
+    display: ${({ $open }) => ($open ? 'flex' : 'none')};
+    transition: none;
   }
 `;
 
@@ -53,36 +50,20 @@ const SidebarInner = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  @media (max-width: ${MOBILE_BP - 1}px) {
+    min-width: unset;
+  }
 `;
 
 const SidebarHeader = styled.div`
   padding: 14px 16px;
-  font-size: 17px;
-  font-weight: 600;
+  font-size: 18px;
+  font-weight: 700;
   color: ${themeable('textColor')};
-  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-`;
-
-const IconBtn = styled.button`
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: ${themeable('textColor')};
-  padding: 4px 6px;
-  border-radius: 6px;
-  font-size: 18px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  opacity: 0.65;
-  &:hover {
-    background: ${themeable('mainBackgroundColor')};
-    opacity: 1;
-  }
 `;
 
 const SidebarScroll = styled.div`
@@ -90,45 +71,88 @@ const SidebarScroll = styled.div`
   flex: 1;
 `;
 
+// ─── Chat item (Telegram style) ───────────────────────────────────────────────
+
 const ChatItem = styled.div<{ $active?: boolean }>`
-  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
   cursor: pointer;
-  border-bottom: 1px solid ${themeable('mainBackgroundColor')};
-  background: ${({ $active }) => ($active ? themeable('primaryColor') : 'transparent')};
-  transition: background 0.15s;
+  background: ${({ $active }) => ($active ? 'rgba(43, 130, 229, 0.1)' : 'transparent')};
+  transition: background 0.1s;
   user-select: none;
   -webkit-user-select: none;
 
   &:hover {
     background: ${({ $active }) =>
-      $active ? themeable('primaryColor') : themeable('mainBackgroundColor')};
+      $active ? 'rgba(43, 130, 229, 0.13)' : themeable('mainBackgroundColor')};
   }
 `;
 
-const ChatItemName = styled.div<{ $active?: boolean }>`
-  font-size: 14px;
+const ChatAvatar = styled.div<{ $color: string }>`
+  width: 50px;
+  height: 50px;
+  min-width: 50px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+  color: #fff;
+  font-size: 19px;
   font-weight: 600;
-  color: ${({ $active }) => ($active ? '#fff' : themeable('textColor'))};
-  margin-bottom: 3px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 `;
 
-const ChatItemPreview = styled.div<{ $active?: boolean }>`
+const ChatMeta = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+`;
+
+const ChatTopRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+`;
+
+const ChatName = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+`;
+
+const ChatTime = styled.span<{ $unread?: boolean }>`
   font-size: 12px;
-  color: ${({ $active }) => ($active ? 'rgba(255,255,255,0.75)' : themeable('textColor'))};
-  opacity: ${({ $active }) => ($active ? 1 : 0.55)};
+  color: ${({ $unread }) => ($unread ? themeable('primaryColor') : themeable('textColor'))};
+  opacity: ${({ $unread }) => ($unread ? 1 : 0.45)};
+  flex-shrink: 0;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
-const ChatItemRow = styled.div`
+const ChatBottomRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 6px;
+`;
+
+const ChatPreview = styled.span`
+  font-size: 13px;
+  color: ${themeable('textColor')};
+  opacity: 0.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 `;
 
 const UnreadBadge = styled.span`
@@ -137,11 +161,13 @@ const UnreadBadge = styled.span`
   font-size: 11px;
   font-weight: 700;
   border-radius: 10px;
-  padding: 1px 6px;
-  min-width: 18px;
+  padding: 2px 7px;
+  min-width: 20px;
   text-align: center;
   flex-shrink: 0;
 `;
+
+// ─── Resize / layout ─────────────────────────────────────────────────────────
 
 const ResizeHandle = styled.div`
   width: 5px;
@@ -149,24 +175,15 @@ const ResizeHandle = styled.div`
   flex-shrink: 0;
   background: transparent;
   transition: background 0.15s;
+
   &:hover,
   &:active {
     background: ${themeable('primaryColor')};
-    opacity: 0.45;
+    opacity: 0.35;
   }
+
   @media (max-width: ${MOBILE_BP - 1}px) {
     display: none;
-  }
-`;
-
-const MobileOverlay = styled.div`
-  display: none;
-  @media (max-width: ${MOBILE_BP - 1}px) {
-    display: block;
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.38);
-    z-index: 9;
   }
 `;
 
@@ -175,29 +192,10 @@ const MainArea = styled.div`
   min-width: 0;
   display: flex;
   flex-direction: column;
-`;
 
-const MobileBar = styled.div`
-  display: none;
   @media (max-width: ${MOBILE_BP - 1}px) {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
-    background: ${themeable('secondaryBackground')};
-    border-bottom: 1px solid ${themeable('mainBackgroundColor')};
-    flex-shrink: 0;
+    display: none;
   }
-`;
-
-const MobileBarTitle = styled.span`
-  font-size: 15px;
-  font-weight: 600;
-  color: ${themeable('textColor')};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
 `;
 
 const EmptyState = styled.div`
@@ -244,9 +242,62 @@ const ContextMenuItem = styled.button<{ $danger?: boolean }>`
   }
 `;
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const AVATAR_COLORS = ['#2b82e5', '#5856d6', '#ff2d55', '#ff9500', '#34c759', '#00c7be', '#af52de'];
+
+function nameToColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+function nameInitials(name: string): string {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map(w => w[0] ?? '')
+    .join('')
+    .toUpperCase();
+}
+
+function formatMsgTime(dateStr?: string): string {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+  if (isToday) {
+    return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) return 'вчера';
+  const diffMs = now.getTime() - d.getTime();
+  if (diffMs < 7 * 24 * 60 * 60 * 1000) {
+    return ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'][d.getDay()];
+  }
+  return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}`;
+}
+
+function previewText(chat: ChatInfo): string {
+  const msg = chat.lastMessage;
+  if (!msg) return '';
+  if (msg.isDeleted) return 'Сообщение удалено';
+  if (msg.attachmentUrl && !msg.text) return '📎 Изображение';
+  return msg.text ?? '';
+}
+
+function chatTitle(chat: ChatInfo): string {
+  return chat.senderName ?? `Чат #${chat.id}`;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
 interface ChatListProps {
   initialChats: ChatInfo[];
   userId: number;
+  selectedChatId?: number;
+  initialChatDetails?: Record<number, ChatDetails>;
 }
 
 interface ChatMenuState {
@@ -255,32 +306,19 @@ interface ChatMenuState {
   y: number;
 }
 
-function formatContact(contactType?: string | null, contactValue?: string | null): string {
-  if (contactType === 'tel' && contactValue) return `Тел: ${contactValue}`;
-  if (contactType === 'email' && contactValue) return `E-mail: ${contactValue}`;
-  if (contactType === 'bot') return 'Через бот';
-  return '';
-}
+// ─── Component ────────────────────────────────────────────────────────────────
 
-function previewText(chat: ChatInfo): string {
-  const msg = chat.lastMessage;
-  if (!msg) return formatContact(chat.contactType, chat.contactValue);
-  if (msg.attachmentUrl && !msg.text) return '📎 Изображение';
-  return msg.text ?? '';
-}
-
-function chatTitle(chat: ChatInfo): string {
-  const name = chat.senderName ?? `Чат #${chat.id}`;
-  const contact = formatContact(chat.contactType, chat.contactValue);
-  return `${name} · ${contact}`;
-}
-
-export function ChatList({ initialChats, userId }: ChatListProps) {
+export function ChatList({
+  initialChats,
+  userId,
+  selectedChatId,
+  initialChatDetails = {}
+}: ChatListProps) {
+  const router = useRouter();
   const { chats, markRead, deleteChatForMe, deleteChatForAll } = useChatList(initialChats);
-  const [selectedId, setSelectedId] = useState<number | null>(null);
-  const [detailsCache, setDetailsCache] = useState<Record<number, ChatDetails>>({});
+  const [selectedId, setSelectedId] = useState<number | null>(selectedChatId ?? null);
+  const [detailsCache, setDetailsCache] = useState<Record<number, ChatDetails>>(initialChatDetails);
   const [loading, setLoading] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
   const [isMobile, setIsMobile] = useState(false);
   const [chatMenu, setChatMenu] = useState<ChatMenuState | null>(null);
@@ -290,17 +328,24 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
   const dragStartWidthRef = useRef(0);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Detect mobile and set initial sidebar state
   useEffect(() => {
-    const check = () => {
-      const mobile = window.innerWidth < MOBILE_BP;
-      setIsMobile(mobile);
-      setSidebarOpen(!mobile);
-    };
+    const check = () => setIsMobile(window.innerWidth < MOBILE_BP);
     check();
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
   }, []);
+
+  // Sync selectedId when selectedChatId prop changes (navigation)
+  useEffect(() => {
+    if (selectedChatId != null) setSelectedId(selectedChatId);
+  }, [selectedChatId]);
+
+  // Merge server-preloaded details into cache
+  useEffect(() => {
+    if (Object.keys(initialChatDetails).length > 0) {
+      setDetailsCache(prev => ({ ...prev, ...initialChatDetails }));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Desktop resize drag
   const startResize = useCallback(
@@ -330,7 +375,6 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
     };
   }, []);
 
-  // Close chat context menu on outside click
   useEffect(() => {
     if (!chatMenu) return;
     const close = () => setChatMenu(null);
@@ -338,12 +382,12 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
     return () => document.removeEventListener('click', close);
   }, [chatMenu]);
 
-  // Cleanup long press timer on unmount
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
-    };
-  }, []);
+    },
+    []
+  );
 
   const loadChat = useCallback(
     async (chatId: number) => {
@@ -365,12 +409,20 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
 
   const handleSelectChat = useCallback(
     (chatId: number) => {
-      setSelectedId(chatId);
       markRead(chatId);
-      if (isMobile) setSidebarOpen(false);
+      if (isMobile) {
+        router.push(`/messages/${chatId}`);
+      } else {
+        setSelectedId(chatId);
+        window.history.pushState(null, '', `/messages/${chatId}`);
+      }
     },
-    [isMobile, markRead]
+    [isMobile, markRead, router]
   );
+
+  const handleBack = useCallback(() => {
+    router.push('/messages');
+  }, [router]);
 
   const handleChatContextMenu = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, chatId: number) => {
@@ -403,40 +455,64 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
   const handleDeleteForMe = useCallback(
     (chatId: number) => {
       deleteChatForMe(chatId);
-      if (selectedId === chatId) setSelectedId(null);
+      if (selectedId === chatId) {
+        setSelectedId(null);
+        if (isMobile) router.push('/messages');
+        else window.history.pushState(null, '', '/messages');
+      }
       setChatMenu(null);
     },
-    [deleteChatForMe, selectedId]
+    [deleteChatForMe, selectedId, isMobile, router]
   );
 
   const handleDeleteForAll = useCallback(
     (chatId: number) => {
       deleteChatForAll(chatId);
-      if (selectedId === chatId) setSelectedId(null);
+      if (selectedId === chatId) {
+        setSelectedId(null);
+        if (isMobile) router.push('/messages');
+        else window.history.pushState(null, '', '/messages');
+      }
       setChatMenu(null);
     },
-    [deleteChatForAll, selectedId]
+    [deleteChatForAll, selectedId, isMobile, router]
   );
 
   const selectedChat = chats.find(c => c.id === selectedId);
   const selectedDetails = selectedId != null ? detailsCache[selectedId] : undefined;
 
+  // Mobile: when a chat is selected, show only the ChatWindow (full screen)
+  if (isMobile && selectedId != null) {
+    if (selectedDetails) {
+      return (
+        <ChatWindow
+          key={selectedId}
+          chatId={selectedId}
+          initialMessages={selectedDetails.messages}
+          currentUserId={userId}
+          isOwner
+          title={selectedChat ? chatTitle(selectedChat) : undefined}
+          onBack={handleBack}
+        />
+      );
+    }
+    if (loading) {
+      return <EmptyState style={{ flex: 1, display: 'flex' }}>Загрузка...</EmptyState>;
+    }
+  }
+
+  // Desktop: split-pane layout / Mobile: just the list
   return (
     <Layout>
-      {isMobile && sidebarOpen && <MobileOverlay onClick={() => setSidebarOpen(false)} />}
-
-      <SidebarPanel $open={sidebarOpen} $width={sidebarWidth}>
+      <SidebarPanel $open $width={sidebarWidth}>
         <SidebarInner>
-          <SidebarHeader>
-            Сообщения
-            <IconBtn onClick={() => setSidebarOpen(false)} title='Закрыть'>
-              ✕
-            </IconBtn>
-          </SidebarHeader>
+          <SidebarHeader>Сообщения</SidebarHeader>
           <SidebarScroll>
             {chats.map(chat => {
               const active = chat.id === selectedId;
               const unread = (chat.unreadCount ?? 0) > 0 && !active;
+              const name = chatTitle(chat);
+              const timeStr = formatMsgTime(chat.lastMessageAt ?? chat.createdAt);
               return (
                 <ChatItem
                   key={chat.id}
@@ -447,13 +523,17 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
                   onTouchEnd={handleChatTouchEnd}
                   onTouchMove={handleChatTouchEnd}
                 >
-                  <ChatItemRow>
-                    <ChatItemName $active={active}>
-                      {chat.senderName ?? `Чат #${chat.id}`}
-                    </ChatItemName>
-                    {unread && <UnreadBadge>{chat.unreadCount}</UnreadBadge>}
-                  </ChatItemRow>
-                  <ChatItemPreview $active={active}>{previewText(chat)}</ChatItemPreview>
+                  <ChatAvatar $color={nameToColor(name)}>{nameInitials(name)}</ChatAvatar>
+                  <ChatMeta>
+                    <ChatTopRow>
+                      <ChatName>{name}</ChatName>
+                      <ChatTime $unread={unread}>{timeStr}</ChatTime>
+                    </ChatTopRow>
+                    <ChatBottomRow>
+                      <ChatPreview>{previewText(chat)}</ChatPreview>
+                      {unread && <UnreadBadge>{chat.unreadCount}</UnreadBadge>}
+                    </ChatBottomRow>
+                  </ChatMeta>
                 </ChatItem>
               );
             })}
@@ -475,16 +555,9 @@ export function ChatList({ initialChats, userId }: ChatListProps) {
         </ContextMenu>
       )}
 
-      {!isMobile && <ResizeHandle onMouseDown={startResize} />}
+      <ResizeHandle onMouseDown={startResize} />
 
       <MainArea>
-        <MobileBar>
-          <IconBtn onClick={() => setSidebarOpen(v => !v)} title='Список чатов'>
-            ☰
-          </IconBtn>
-          <MobileBarTitle>{selectedChat ? chatTitle(selectedChat) : 'Сообщения'}</MobileBarTitle>
-        </MobileBar>
-
         {selectedChat && selectedDetails ? (
           <ChatWindow
             key={selectedId}

--- a/packages/web/src/components/Chat/ChatWindow.tsx
+++ b/packages/web/src/components/Chat/ChatWindow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { Select as HeroSelect, SelectItem } from '@heroui/react';
 import { Input as HeroInput } from '@heroui/input';
 
@@ -33,12 +33,32 @@ const Wrapper = styled.div`
 const Header = styled.div`
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 16px;
+  gap: 8px;
+  padding: 0 12px 0 8px;
   min-height: 52px;
   flex-shrink: 0;
   background: ${themeable('secondaryBackground')};
   border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+`;
+
+const BackBtn = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  color: ${themeable('primaryColor')};
+  font-size: 22px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${themeable('mainBackgroundColor')};
+  }
 `;
 
 const HeaderTitle = styled.div`
@@ -64,33 +84,120 @@ const HeaderStatus = styled.div<{ $typing: boolean; $online: boolean }>`
   font-style: ${({ $typing }) => ($typing ? 'italic' : 'normal')};
 `;
 
+// ─── Selection bar (top, replaces header in selection mode) ──────────────────
+
+const SelectionBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  min-height: 52px;
+  background: ${themeable('secondaryBackground')};
+  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+  flex-shrink: 0;
+`;
+
+const SelectionCancelBtn = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  color: ${themeable('textColor')};
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+  flex-shrink: 0;
+
+  &:hover {
+    opacity: 1;
+    background: ${themeable('mainBackgroundColor')};
+  }
+`;
+
+const SelectionCount = styled.span`
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  color: ${themeable('textColor')};
+`;
+
+const SelectionActionBtn = styled.button<{ $danger?: boolean }>`
+  background: none;
+  border: 1px solid ${({ $danger }) => ($danger ? '#e53e3e' : themeable('primaryColor'))};
+  border-radius: 16px;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  color: ${({ $danger }) => ($danger ? '#e53e3e' : themeable('primaryColor'))};
+  transition: background 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    background: ${({ $danger }) => ($danger ? 'rgba(229,62,62,0.08)' : 'rgba(43,130,229,0.08)')};
+  }
+`;
+
 // ─── Message list ─────────────────────────────────────────────────────────────
 
 const MsgList = styled.div`
   flex: 1;
   overflow-y: auto;
-  padding: 12px 16px 8px;
+  padding: 12px 12px 8px;
   display: flex;
   flex-direction: column;
   gap: 3px;
   overscroll-behavior: contain;
-  scroll-behavior: smooth;
 `;
 
-const MsgRow = styled.div<{ $out: boolean; $selected?: boolean }>`
+const MsgRow = styled.div<{ $out: boolean; $selectionMode?: boolean }>`
   display: flex;
   justify-content: ${({ $out }) => ($out ? 'flex-end' : 'flex-start')};
   align-items: flex-end;
   gap: 2px;
   position: relative;
-  border-radius: 6px;
-  margin: 0 -8px;
-  padding: 1px 8px;
-  background: ${({ $selected }) => ($selected ? 'rgba(43, 130, 229, 0.13)' : 'transparent')};
-  transition: background 0.1s;
+  padding: 1px ${({ $selectionMode }) => ($selectionMode ? '4px' : '0')};
+  padding-left: ${({ $selectionMode }) => ($selectionMode ? '36px' : '0')};
+  transition: padding-left 0.18s;
 `;
 
-const Bubble = styled.div<{ $out: boolean; $deleted?: boolean; $selectionMode?: boolean }>`
+// ─── Telegram-style selection checkmark ──────────────────────────────────────
+
+const SelectionCheckmark = styled.div<{ $selected: boolean }>`
+  position: absolute;
+  left: 4px;
+  bottom: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid
+    ${({ $selected }) => ($selected ? themeable('primaryColor') : 'rgba(128,128,128,0.38)')};
+  background: ${({ $selected }) => ($selected ? themeable('primaryColor') : 'transparent')};
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+  cursor: pointer;
+`;
+
+const Bubble = styled.div<{
+  $out: boolean;
+  $deleted?: boolean;
+  $selectionMode?: boolean;
+  $selected?: boolean;
+}>`
   max-width: 75%;
   padding: 8px 12px 6px;
   border-radius: ${({ $out }) => ($out ? '18px 18px 4px 18px' : '18px 18px 18px 4px')};
@@ -101,12 +208,16 @@ const Bubble = styled.div<{ $out: boolean; $deleted?: boolean; $selectionMode?: 
   font-size: 14px;
   line-height: 1.45;
   word-break: break-word;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.14);
+  box-shadow: ${({ $selected }) =>
+    $selected
+      ? '0 0 0 2px var(--cs-primary, #2b82e5), 0 1px 3px rgba(0,0,0,0.14)'
+      : '0 1px 3px rgba(0,0,0,0.14)'};
   position: relative;
   opacity: ${({ $deleted }) => ($deleted ? 0.5 : 1)};
   cursor: ${({ $selectionMode }) => ($selectionMode ? 'pointer' : 'default')};
   user-select: none;
   -webkit-user-select: none;
+  transition: box-shadow 0.15s;
 `;
 
 const BubbleText = styled.span`
@@ -127,6 +238,36 @@ const BubbleTime = styled.span<{ $out: boolean }>`
   bottom: 6px;
   right: 10px;
   color: ${({ $out }) => ($out ? 'rgba(255,255,255,0.85)' : themeable('textColor'))};
+`;
+
+// ─── Image skeleton ───────────────────────────────────────────────────────────
+
+const shimmer = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
+const ImgSkeleton = styled.div`
+  width: 220px;
+  height: 160px;
+  border-radius: 12px;
+  background: linear-gradient(
+    90deg,
+    rgba(128, 128, 128, 0.15) 25%,
+    rgba(128, 128, 128, 0.28) 50%,
+    rgba(128, 128, 128, 0.15) 75%
+  );
+  background-size: 200% 100%;
+  animation: ${shimmer} 1.5s infinite;
+  margin-bottom: 2px;
+`;
+
+const AttachImg = styled.img`
+  max-width: 220px;
+  max-height: 220px;
+  border-radius: 12px;
+  display: block;
+  margin-bottom: 2px;
 `;
 
 // ─── Context menu ─────────────────────────────────────────────────────────────
@@ -164,65 +305,6 @@ const ContextMenuItem = styled.button<{ $danger?: boolean }>`
   }
 `;
 
-// ─── Selection bar ────────────────────────────────────────────────────────────
-
-const SelectionBar = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: ${themeable('secondaryBackground')};
-  border-top: 1px solid rgba(128, 128, 128, 0.12);
-  flex-shrink: 0;
-`;
-
-const SelectionCount = styled.span`
-  flex: 1;
-  font-size: 14px;
-  font-weight: 500;
-  color: ${themeable('textColor')};
-`;
-
-const SelectionActionBtn = styled.button<{ $danger?: boolean }>`
-  background: none;
-  border: 1px solid ${({ $danger }) => ($danger ? '#e53e3e' : themeable('primaryColor'))};
-  border-radius: 16px;
-  padding: 5px 12px;
-  font-size: 13px;
-  cursor: pointer;
-  color: ${({ $danger }) => ($danger ? '#e53e3e' : themeable('primaryColor'))};
-  transition: background 0.15s;
-  white-space: nowrap;
-
-  &:hover {
-    background: ${({ $danger }) => ($danger ? 'rgba(229,62,62,0.08)' : 'rgba(43,130,229,0.08)')};
-  }
-`;
-
-const SelectionCancelBtn = styled.button`
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 50%;
-  color: ${themeable('textColor')};
-  font-size: 18px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.6;
-  transition:
-    opacity 0.15s,
-    background 0.15s;
-  flex-shrink: 0;
-
-  &:hover {
-    opacity: 1;
-    background: ${themeable('mainBackgroundColor')};
-  }
-`;
-
 // ─── System message ───────────────────────────────────────────────────────────
 
 const SystemMsgRow = styled.div`
@@ -239,14 +321,6 @@ const SystemMsgBubble = styled.div`
   padding: 4px 14px;
   border-radius: 12px;
   text-align: center;
-`;
-
-const AttachImg = styled.img`
-  max-width: 220px;
-  max-height: 220px;
-  border-radius: 12px;
-  display: block;
-  margin-bottom: 2px;
 `;
 
 // ─── Contact panel ────────────────────────────────────────────────────────────
@@ -333,10 +407,7 @@ const SendBtn = styled(RoundBtn)<{ $active: boolean }>`
 
 function formatTime(iso: string): string {
   const d = new Date(iso);
-  return `${d.getHours().toString().padStart(2, '0')}:${d
-    .getMinutes()
-    .toString()
-    .padStart(2, '0')}`;
+  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
 }
 
 const CONTACT_OPTIONS = [
@@ -353,6 +424,7 @@ interface ChatWindowProps {
   isOwner?: boolean;
   title?: string;
   initialContact?: Pick<ChatDetails, 'contactType' | 'contactValue'>;
+  onBack?: () => void;
 }
 
 interface MenuState {
@@ -368,7 +440,8 @@ export function ChatWindow({
   initialMessages,
   isOwner = false,
   title,
-  initialContact
+  initialContact,
+  onBack
 }: ChatWindowProps) {
   const {
     messages,
@@ -381,22 +454,25 @@ export function ChatWindow({
     deleteMessagesForAll,
     deleteMessagesForMe
   } = useChat({ chatId, initialMessages, isOwner });
+
   const listRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textRef = useRef<HTMLTextAreaElement>(null);
   const isAtBottomRef = useRef(true);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [text, setText] = useState('');
   const [uploading, setUploading] = useState(false);
   const [contactType, setContactType] = useState(initialContact?.contactType ?? 'none');
   const [contactValue, setContactValue] = useState(initialContact?.contactValue ?? '');
   const [menuState, setMenuState] = useState<MenuState | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set<number>());
+  const [imgLoaded, setImgLoaded] = useState<Record<number, boolean>>({});
+
   const selectionMode = selectedIds.size > 0;
 
   const closeMenu = useCallback(() => setMenuState(null), []);
-
-  const exitSelection = useCallback(() => setSelectedIds(new Set()), []);
+  const exitSelection = useCallback(() => setSelectedIds(new Set<number>()), []);
 
   const toggleSelect = useCallback((msgId: number) => {
     setSelectedIds(prev => {
@@ -407,22 +483,20 @@ export function ChatWindow({
     });
   }, []);
 
-  // Track whether user is at the bottom of the scroll
+  // Track scroll position
   const handleScroll = useCallback(() => {
     const el = listRef.current;
     if (!el) return;
     isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
   }, []);
 
-  // Auto-scroll only when user is at the bottom
+  // Auto-scroll when at bottom
   useEffect(() => {
     const el = listRef.current;
-    if (el && isAtBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
+    if (el && isAtBottomRef.current) el.scrollTop = el.scrollHeight;
   }, [messages]);
 
-  // Always scroll to bottom on chat switch
+  // Scroll to bottom on chat switch
   useEffect(() => {
     const el = listRef.current;
     if (el) {
@@ -439,12 +513,12 @@ export function ChatWindow({
     return () => document.removeEventListener('click', close);
   }, [menuState]);
 
-  // Cleanup long press timer on unmount
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
-    };
-  }, []);
+    },
+    []
+  );
 
   // Right-click: in selection mode toggles selection, otherwise opens context menu
   const handleContextMenu = useCallback(
@@ -462,7 +536,7 @@ export function ChatWindow({
     [selectionMode, toggleSelect]
   );
 
-  // Click in selection mode toggles selection
+  // Click on bubble in selection mode toggles selection
   const handleBubbleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!selectionMode) return;
@@ -569,15 +643,36 @@ export function ChatWindow({
 
   return (
     <Wrapper>
-      {title && (
-        <Header>
-          <HeaderTitle>
-            <HeaderName>{title}</HeaderName>
-            <HeaderStatus $typing={partnerTyping} $online={connected}>
-              {partnerTyping ? 'печатает...' : connected ? 'в сети' : 'соединение...'}
-            </HeaderStatus>
-          </HeaderTitle>
-        </Header>
+      {/* Top bar: selection bar or header */}
+      {selectionMode ? (
+        <SelectionBar>
+          <SelectionCancelBtn onClick={exitSelection} title='Отменить выделение'>
+            ✕
+          </SelectionCancelBtn>
+          <SelectionCount>{selectedIds.size} выбрано</SelectionCount>
+          <SelectionActionBtn onClick={handleDeleteSelectedForMe}>
+            Удалить у меня
+          </SelectionActionBtn>
+          <SelectionActionBtn $danger onClick={handleDeleteSelectedForAll}>
+            Удалить у всех
+          </SelectionActionBtn>
+        </SelectionBar>
+      ) : (
+        title && (
+          <Header>
+            {onBack && (
+              <BackBtn onClick={onBack} title='Назад'>
+                ‹
+              </BackBtn>
+            )}
+            <HeaderTitle>
+              <HeaderName>{title}</HeaderName>
+              <HeaderStatus $typing={partnerTyping} $online={connected}>
+                {partnerTyping ? 'печатает...' : connected ? 'в сети' : 'соединение...'}
+              </HeaderStatus>
+            </HeaderTitle>
+          </Header>
+        )
       )}
 
       {!isOwner && messages.length === 0 && (
@@ -625,13 +720,20 @@ export function ChatWindow({
           }
 
           const out = (msg.source === MessageSource.Sender) !== isOwner;
+          const selected = selectedIds.has(msg.id);
 
           return (
-            <MsgRow key={msg.id} $out={out} $selected={selectedIds.has(msg.id)}>
+            <MsgRow key={msg.id} $out={out} $selectionMode={selectionMode}>
+              {selectionMode && (
+                <SelectionCheckmark $selected={selected} onClick={() => toggleSelect(msg.id)}>
+                  {selected && '✓'}
+                </SelectionCheckmark>
+              )}
               <Bubble
                 $out={out}
                 $deleted={msg.isDeleted}
                 $selectionMode={selectionMode}
+                $selected={selected}
                 data-msgid={msg.id}
                 onClick={handleBubbleClick}
                 onContextMenu={handleContextMenu}
@@ -640,7 +742,15 @@ export function ChatWindow({
                 onTouchMove={handleTouchEnd}
               >
                 {msg.attachmentUrl && !msg.isDeleted && (
-                  <AttachImg src={msg.attachmentUrl} alt='attachment' />
+                  <>
+                    {!imgLoaded[msg.id] && <ImgSkeleton />}
+                    <AttachImg
+                      src={msg.attachmentUrl}
+                      alt='attachment'
+                      style={{ display: imgLoaded[msg.id] ? 'block' : 'none' }}
+                      onLoad={() => setImgLoaded(prev => ({ ...prev, [msg.id]: true }))}
+                    />
+                  </>
                 )}
                 {msg.isDeleted ? (
                   <DeletedText>Сообщение удалено</DeletedText>
@@ -681,54 +791,39 @@ export function ChatWindow({
         </ContextMenu>
       )}
 
-      {selectionMode ? (
-        <SelectionBar>
-          <SelectionCancelBtn onClick={exitSelection} title='Отменить выделение'>
-            ✕
-          </SelectionCancelBtn>
-          <SelectionCount>{selectedIds.size} выбрано</SelectionCount>
-          <SelectionActionBtn onClick={handleDeleteSelectedForMe}>
-            Удалить у меня
-          </SelectionActionBtn>
-          <SelectionActionBtn $danger onClick={handleDeleteSelectedForAll}>
-            Удалить у всех
-          </SelectionActionBtn>
-        </SelectionBar>
-      ) : (
-        <InputArea>
-          <RoundBtn
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            title='Прикрепить изображение'
-          >
-            📎
-          </RoundBtn>
-          <input
-            ref={fileInputRef}
-            type='file'
-            accept='image/*'
-            style={{ display: 'none' }}
-            onChange={handleAttach}
-          />
-          <TextInput
-            ref={textRef}
-            rows={1}
-            placeholder={connected ? 'Сообщение...' : 'Соединение...'}
-            value={text}
-            onChange={handleTextChange}
-            onKeyDown={handleKeyDown}
-            disabled={!connected}
-          />
-          <SendBtn
-            $active={!!text.trim() && connected}
-            onClick={handleSend}
-            disabled={!text.trim() || !connected}
-            title='Отправить'
-          >
-            ➤
-          </SendBtn>
-        </InputArea>
-      )}
+      <InputArea>
+        <RoundBtn
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          title='Прикрепить изображение'
+        >
+          📎
+        </RoundBtn>
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept='image/*'
+          style={{ display: 'none' }}
+          onChange={handleAttach}
+        />
+        <TextInput
+          ref={textRef}
+          rows={1}
+          placeholder={connected ? 'Сообщение...' : 'Соединение...'}
+          value={text}
+          onChange={handleTextChange}
+          onKeyDown={handleKeyDown}
+          disabled={!connected}
+        />
+        <SendBtn
+          $active={!!text.trim() && connected}
+          onClick={handleSend}
+          disabled={!text.trim() || !connected}
+          title='Отправить'
+        >
+          ➤
+        </SendBtn>
+      </InputArea>
     </Wrapper>
   );
 }


### PR DESCRIPTION
## Что сделано

- **Отдельная ссылка для каждого чата** — новый роут `/messages/[chatId]` с серверной загрузкой данных чата
- **Список чатов как в Telegram** — аватар с инициалами (цвет из имени), имя, превью последнего сообщения, время, бейдж непрочитанных
- **Выделение сообщений как в Telegram** — кружок с галочкой слева от каждого сообщения (position:absolute) + синяя обводка (box-shadow) на пузырьке. Фон строки не меняется
- **Плашка выделения сверху** — заменяет шапку чата при активном выделении (как в Telegram)
- **Кнопка «Назад» (‹)** — появляется в шапке чата на мобильном, возвращает в список
- **Мобильный UX**: `/messages` → только список, `/messages/[chatId]` → полноэкранный чат с кнопкой назад
- **Десктоп**: split-pane, URL синхронизируется через `history.pushState` без перезагрузки
- **Скелетон картинки** — shimmer-анимация пока вложение не загрузилось
- **Шапка и поле ввода закреплены** — flex-column layout, flex-shrink:0 на обоих

## Test plan

- [ ] Мобильный: открыть `/messages` → список чатов, тап на чат → переход на `/messages/[chatId]`, кнопка ‹ → обратно в список
- [ ] Десктоп: sidebar + чат рядом, клик на другой чат → URL меняется без перезагрузки страницы
- [ ] Прямая ссылка `/messages/123` — данные чата преданы с сервера, чат открывается без лоадера
- [ ] Список: аватары с инициалами, время, превью, бейдж непрочитанных
- [ ] Выделение: долгий тап/правый клик → кружки на сообщениях, выбранные с синей обводкой
- [ ] Плашка «N выбрано» появляется СВЕРХУ (заменяет шапку)
- [ ] Картинка в сообщении показывает shimmer пока не загрузится
- [ ] Шапка и ввод не скроллятся вместе с сообщениями

https://claude.ai/code/session_01EhYs3UF3MfBVEZYW3Sjsps

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhYs3UF3MfBVEZYW3Sjsps)_