### PR TITLE
fix(chat): authenticate socket via httpOnly JWT cookie so MARK_READ works

### DIFF
--- a/packages/backend/src/app/chat/chat.gateway.ts
+++ b/packages/backend/src/app/chat/chat.gateway.ts
@@ -32,9 +32,13 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {}
 
   async handleConnection(client: Socket) {
+    const rawCookie = client.handshake.headers?.cookie ?? '';
+    const parsed = rawCookie ? parseCookies(rawCookie) : {};
+
     const token =
       client.handshake.auth?.token ||
-      client.handshake.headers?.['x-user-token'];
+      client.handshake.headers?.['x-user-token'] ||
+      parsed[this.configService.auth.jwtCookie];
 
     if (token) {
       try {
@@ -48,12 +52,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
     }
 
-    const rawCookie = client.handshake.headers?.cookie ?? '';
-    if (rawCookie) {
-      const parsed = parseCookies(rawCookie);
-      const cookieName = this.configService.auth.anonymousIdCookie;
-      client.data.anonymousId = parsed[cookieName];
-    }
+    client.data.anonymousId = parsed[this.configService.auth.anonymousIdCookie];
   }
 
   handleDisconnect(_client: Socket) {}


### PR DESCRIPTION
## Проблема

Счётчик непрочитанных не сбрасывался при открытии чата.

**Причина:** WebSocket-соединение аутентифицировалось только через `handshake.auth.token` (токен из localStorage). Если пользователь вошёл через httpOnly cookie (стандартный сценарий — JS не может читать такую cookie), сокет подключался анонимно. Gateway в `handleMarkRead` видел `userId = undefined` и сразу возвращал управление, не обновляя `recieverReadAt` в БД. Локальный оптимистичный сброс работал, но на сервере ничего не менялось.

## Исправление

В `chat.gateway.ts`, `handleConnection` теперь дополнительно читает JWT из cookie handshake:

```ts
const token =
  client.handshake.auth?.token ||
  client.handshake.headers?.['x-user-token'] ||
  parsed[this.configService.auth.jwtCookie];  // ← новое
```

Cookie уже парсились для `anonymous_id` — просто добавляем чтение `jwtCookie` из тех же разобранных данных.

## Test plan

- [ ] Войти в аккаунт (через auth cookie)
- [ ] Получить сообщение → счётчик появляется в списке чатов
- [ ] Открыть чат → счётчик исчезает сразу и не возвращается при обновлении страницы

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_