### PR TITLE
feat(auth): logout endpoint moved to backend

### DIFF
--- a/packages/backend/src/app/auth/auth.controller.ts
+++ b/packages/backend/src/app/auth/auth.controller.ts
@@ -77,6 +77,16 @@ export class AuthController implements AuthApi {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   async checkAuthorized(): Promise<void> {}
 
+  @Post(AUTH_API.backendRoutes.logout)
+  async logout(@Res({ passthrough: true }) res: Response): Promise<void> {
+    res.clearCookie(this.configService.auth.jwtCookie, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+      path: '/',
+    });
+  }
+
   @Post(AUTH_API.backendRoutes.authTelegramWebApp)
   async authTelegramWebApp(
     @Body() { data }: AuthTelegramWebAppData,

--- a/packages/shared/src/auth/auth.api.ts
+++ b/packages/shared/src/auth/auth.api.ts
@@ -15,6 +15,7 @@ export interface AuthApi {
   authTelegram(data: AuthTelegramData, ...args: any): Promise<string>;
   authTelegramWebApp(data: AuthTelegramWebAppData, ...args: any): Promise<string>;
   checkAuthorized(...args: any): Promise<void>;
+  logout(...args: any): Promise<void>;
   getLinkedAccounts(...args: any): Promise<LinkedAccount[]>;
   unlinkProvider(provider: OAuthProvider, ...args: any): Promise<void>;
 }
@@ -25,6 +26,7 @@ const AUTH_ROUTES: APIRoutes<AuthApi> = {
   authTelegram: { method: 'POST', path: 'telegram' },
   authTelegramWebApp: { method: 'POST', path: 'telegram-web-app' },
   checkAuthorized: 'check',
+  logout: { method: 'POST', path: 'logout' },
   getLinkedAccounts: { method: 'GET', path: 'linked' },
   unlinkProvider: {
     method: 'DELETE',

--- a/packages/web/src/app/api/logout/route.ts
+++ b/packages/web/src/app/api/logout/route.ts
@@ -1,8 +1,0 @@
-import { AUTH_COOKIE_NAME } from '@/helpers/constants';
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-
-export async function GET() {
-  (await cookies()).delete(AUTH_COOKIE_NAME);
-  redirect('/auth');
-}

--- a/packages/web/src/app/profile/ProfileClient.tsx
+++ b/packages/web/src/app/profile/ProfileClient.tsx
@@ -329,9 +329,13 @@ function ProfileContent({ initialProfile }: { initialProfile: UserProfile }) {
           color='danger'
           variant='flat'
           className='w-full'
-          onPress={() => {
-            clearStoredAuthToken();
-            window.location.href = '/api/logout';
+          onPress={async () => {
+            try {
+              await authService.logout();
+            } finally {
+              clearStoredAuthToken();
+              window.location.href = '/auth';
+            }
           }}
         >
           Выйти


### PR DESCRIPTION
## Summary

- Добавлен endpoint `POST /auth/logout` в NestJS backend — удаляет httpOnly cookie
- Обновлён `AuthApi` интерфейс и `AUTH_ROUTES` в shared пакете
- Кнопка "Выйти" в профиле теперь вызывает `authService.logout()` вместо редиректа на `/api/logout`
- Удалён Next.js route handler `app/api/logout/route.ts`

## Test plan

- [ ] Нажать "Выйти" в профиле — должен разлогинить и перейти на `/auth`
- [ ] Убедиться, что cookie `auth` удаляется после выхода
- [ ] localStorage тоже очищается (clearStoredAuthToken)

https://claude.ai/code/session_01EhYs3UF3MfBVEZYW3Sjsps

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhYs3UF3MfBVEZYW3Sjsps)_