### PR TITLE
Add browser push notifications

### DIFF
--- a/packages/backend/config.example.yaml
+++ b/packages/backend/config.example.yaml
@@ -40,3 +40,9 @@ s3:
   endpoint: your_endpoint
   bucket: your_bucket_name
   region: your_region
+
+# Generate with: npx web-push generate-vapid-keys
+vapid:
+  subject: mailto:admin@example.com
+  publicKey: YOUR_VAPID_PUBLIC_KEY
+  privateKey: YOUR_VAPID_PRIVATE_KEY

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/schedule": "^5.0.1",
         "@nestjs/typeorm": "^10.0.2",
         "@paulislava/shared": "file:../shared",
+        "@types/web-push": "3.6.4",
         "bcrypt": "^5.1.1",
         "body-parser": "^1.20.2",
         "cjstoesm": "^2.1.2",
@@ -47,7 +48,8 @@
         "typeorm": "^0.3.20",
         "typeorm-naming-strategies": "^4.1.0",
         "typeorm-transactional": "^0.5.0",
-        "useragent": "^2.3.0"
+        "useragent": "^2.3.0",
+        "web-push": "3.6.7"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -4109,6 +4111,15 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -4877,6 +4888,18 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
@@ -5117,6 +5140,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -8169,6 +8198,15 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -10056,6 +10094,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -14057,6 +14101,91 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/web-push/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/web-push/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/web-resource-inliner": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-6.0.1.tgz",
@@ -17614,6 +17743,14 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
     },
+    "@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -18183,6 +18320,17 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
@@ -18368,6 +18516,11 @@
           }
         }
       }
+    },
+    "bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
     },
     "body-parser": {
       "version": "1.20.2",
@@ -20574,6 +20727,11 @@
         "entities": "^4.4.0"
       }
     },
+    "http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -22030,6 +22188,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.1.2",
@@ -24957,6 +25120,66 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+        },
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "jwa": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+          "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+          "requires": {
+            "buffer-equal-constant-time": "^1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+          "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+          "requires": {
+            "jwa": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "web-resource-inliner": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@nestjs/schedule": "^5.0.1",
     "@nestjs/typeorm": "^10.0.2",
     "@paulislava/shared": "file:../shared",
+    "@types/web-push": "3.6.4",
     "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
     "cjstoesm": "^2.1.2",
@@ -59,7 +60,8 @@
     "typeorm": "^0.3.20",
     "typeorm-naming-strategies": "^4.1.0",
     "typeorm-transactional": "^0.5.0",
-    "useragent": "^2.3.0"
+    "useragent": "^2.3.0",
+    "web-push": "3.6.7"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { FileModule } from './app/file/file.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ChatModule } from './app/chat/chat.module';
 import { AdminModule } from './app/admin/admin.module';
+import { NotificationModule } from './app/notification/notification.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { AdminModule } from './app/admin/admin.module';
     ChatModule,
     CarModule,
     AdminModule,
+    NotificationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/backend/src/app/car/car.service.ts
+++ b/packages/backend/src/app/car/car.service.ts
@@ -52,6 +52,8 @@ import { User } from '../entities/user/user.entity';
 import { CarDriver } from '../entities/car/car-driver.entity';
 import { CarRating } from '../entities/car/car-rating.entity';
 import { UserService } from '../users/user.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CarNotificationEvent } from '@paulislava/shared/notification/notification.types';
 
 const carMainRelations = ['owner', 'carDrivers', 'carDrivers.driver'];
 
@@ -78,6 +80,7 @@ export class CarService {
     private readonly configService: ConfigService,
     private readonly chatService: ChatService,
     private readonly userService: UserService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async getList(): Promise<CarInfo[]> {
@@ -193,6 +196,15 @@ export class CarService {
 
     await this.callRepository.save({ car: { id }, ip });
 
+    this.eventEmitter.emit('car.call', {
+      type: 'call',
+      carId: id,
+      carCode: car.code,
+      carNo: no,
+      title: 'Вас вызвали',
+      body: `Водителя вызвали к автомобилю ${no}`,
+    } satisfies CarNotificationEvent);
+
     const drivers = [owner, ...carDrivers.map((cd) => cd.driver)];
 
     drivers.forEach(async (driver) => {
@@ -243,6 +255,15 @@ export class CarService {
       res,
       req,
     );
+
+    this.eventEmitter.emit('car.message', {
+      type: 'message',
+      carId: car.id,
+      carCode: car.code,
+      carNo: car.no,
+      title: 'Новое сообщение',
+      body: text.slice(0, 100),
+    } satisfies CarNotificationEvent);
   }
 
   async getFullInfo(id: number, user?: RequestUser): Promise<FullCarInfo> {
@@ -706,6 +727,15 @@ export class CarService {
       rating: averageRating,
       ratesCount,
     });
+
+    this.eventEmitter.emit('car.rating', {
+      type: 'rating',
+      carId,
+      carCode: car.code,
+      carNo: car.no,
+      title: 'Новая оценка',
+      body: `Автомобиль ${car.no} получил оценку ${'★'.repeat(rating)}`,
+    } satisfies CarNotificationEvent);
   }
 
   private async validateCarData(

--- a/packages/backend/src/app/config/config.schema.ts
+++ b/packages/backend/src/app/config/config.schema.ts
@@ -120,6 +120,20 @@ export class TelegramConfig {
   token: string;
 }
 
+export class VapidConfig {
+  @IsString()
+  @IsDefined()
+  readonly subject: string;
+
+  @IsString()
+  @IsDefined()
+  readonly publicKey: string;
+
+  @IsString()
+  @IsDefined()
+  readonly privateKey: string;
+}
+
 export class S3Config {
   @IsString()
   @IsDefined()
@@ -177,6 +191,11 @@ export class ApplicationConfig {
   @ValidateNested()
   @Type(() => S3Config)
   readonly s3: S3Config;
+
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => VapidConfig)
+  readonly vapid: VapidConfig;
 }
 
 export interface Version {

--- a/packages/backend/src/app/config/config.service.ts
+++ b/packages/backend/src/app/config/config.service.ts
@@ -15,6 +15,7 @@ import {
   S3Config,
   SmsConfig,
   TelegramConfig,
+  VapidConfig,
   Version,
   WebdavConfig,
 } from './config.schema';
@@ -54,6 +55,10 @@ export class ConfigService implements ApplicationConfig {
 
   get s3(): S3Config {
     return this.config.s3;
+  }
+
+  get vapid(): VapidConfig {
+    return this.config.vapid;
   }
 
   get version(): Version {

--- a/packages/backend/src/app/entities/push-subscription.entity.ts
+++ b/packages/backend/src/app/entities/push-subscription.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { User } from './user/user.entity';
+
+@Entity('push_subscriptions')
+@Unique(['userId', 'endpoint'])
+@Index(['userId'])
+export class PushSubscription {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column()
+  userId: number;
+
+  @Column({ type: 'text' })
+  endpoint: string;
+
+  @Column()
+  p256dh: string;
+
+  @Column()
+  auth: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/app/notification/notification.controller.ts
+++ b/packages/backend/src/app/notification/notification.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+
+import { NotificationService } from './notification.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../users/user.decorator';
+import { RequestUser } from '@paulislava/shared/user/user.types';
+import NOTIFICATION_API from '@paulislava/shared/notification/notification.api';
+import { PushSubscribeBody, PushUnsubscribeBody } from '@paulislava/shared/notification/notification.types';
+
+class PushKeysDto {
+  @IsString()
+  p256dh: string;
+
+  @IsString()
+  auth: string;
+}
+
+class SubscribeDto implements PushSubscribeBody {
+  @IsString()
+  endpoint: string;
+
+  @ValidateNested()
+  @Type(() => PushKeysDto)
+  keys: PushKeysDto;
+}
+
+class UnsubscribeDto implements PushUnsubscribeBody {
+  @IsString()
+  endpoint: string;
+}
+
+@Controller(NOTIFICATION_API.path)
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @Get(NOTIFICATION_API.backendRoutes.vapidPublicKey)
+  vapidPublicKey(): { publicKey: string } {
+    return { publicKey: this.notificationService.getVapidPublicKey() };
+  }
+
+  @Post(NOTIFICATION_API.backendRoutes.subscribe)
+  @UseGuards(JwtAuthGuard)
+  async subscribe(
+    @Body() body: SubscribeDto,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.notificationService.subscribe(
+      user.userId,
+      body.endpoint,
+      body.keys.p256dh,
+      body.keys.auth,
+    );
+  }
+
+  @Post(NOTIFICATION_API.backendRoutes.unsubscribe)
+  @UseGuards(JwtAuthGuard)
+  async unsubscribe(
+    @Body() body: UnsubscribeDto,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.notificationService.unsubscribe(user.userId, body.endpoint);
+  }
+}

--- a/packages/backend/src/app/notification/notification.module.ts
+++ b/packages/backend/src/app/notification/notification.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { NotificationController } from './notification.controller';
+import { NotificationService } from './notification.service';
+import { PushSubscription } from '../entities/push-subscription.entity';
+import { Car } from '../entities/car/car.entity';
+import { CarDriver } from '../entities/car/car-driver.entity';
+import { ConfigModule } from '../config/config.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PushSubscription, Car, CarDriver]),
+    ConfigModule,
+  ],
+  controllers: [NotificationController],
+  providers: [NotificationService],
+})
+export class NotificationModule {}

--- a/packages/backend/src/app/notification/notification.service.ts
+++ b/packages/backend/src/app/notification/notification.service.ts
@@ -51,6 +51,7 @@ export class NotificationService {
 
   @OnEvent('car.message')
   async onCarMessage(event: CarNotificationEvent): Promise<void> {
+    this.logger.debug(`car.message event received for carId=${event.carId}`);
     await this.sendToCarOwners(event.carId, {
       type: event.type,
       carCode: event.carCode,
@@ -83,12 +84,14 @@ export class NotificationService {
     const car = await this.carRepository.findOne({ where: { id: carId } });
     if (!car) return;
 
-    const carDrivers = await this.carDriverRepository.find({ where: { car: { id: carId } } });
+    const carDrivers = await this.carDriverRepository.find({ where: { carId } });
     const userIds = [car.ownerId, ...carDrivers.map((cd) => cd.driverId)];
 
     const subscriptions = await this.pushSubscriptionRepository.find({
       where: { userId: In(userIds) },
     });
+
+    this.logger.debug(`Sending push to ${subscriptions.length} subscription(s) for carId=${carId}`);
 
     const payloadStr = JSON.stringify(payload);
 

--- a/packages/backend/src/app/notification/notification.service.ts
+++ b/packages/backend/src/app/notification/notification.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { OnEvent } from '@nestjs/event-emitter';
+import * as webpush from 'web-push';
+
+import { PushSubscription } from '../entities/push-subscription.entity';
+import { CarDriver } from '../entities/car/car-driver.entity';
+import { Car } from '../entities/car/car.entity';
+import { ConfigService } from '../config/config.service';
+import { CarNotificationEvent, PushPayload } from '@paulislava/shared/notification/notification.types';
+
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+
+  constructor(
+    @InjectRepository(PushSubscription)
+    private readonly pushSubscriptionRepository: Repository<PushSubscription>,
+    @InjectRepository(Car)
+    private readonly carRepository: Repository<Car>,
+    @InjectRepository(CarDriver)
+    private readonly carDriverRepository: Repository<CarDriver>,
+    private readonly configService: ConfigService,
+  ) {
+    const { subject, publicKey, privateKey } = configService.vapid;
+    webpush.setVapidDetails(subject, publicKey, privateKey);
+  }
+
+  getVapidPublicKey(): string {
+    return this.configService.vapid.publicKey;
+  }
+
+  async subscribe(userId: number, endpoint: string, p256dh: string, auth: string): Promise<void> {
+    const existing = await this.pushSubscriptionRepository.findOne({
+      where: { userId, endpoint },
+    });
+
+    if (existing) {
+      existing.p256dh = p256dh;
+      existing.auth = auth;
+      await this.pushSubscriptionRepository.save(existing);
+    } else {
+      await this.pushSubscriptionRepository.save({ userId, endpoint, p256dh, auth });
+    }
+  }
+
+  async unsubscribe(userId: number, endpoint: string): Promise<void> {
+    await this.pushSubscriptionRepository.delete({ userId, endpoint });
+  }
+
+  @OnEvent('car.message')
+  async onCarMessage(event: CarNotificationEvent): Promise<void> {
+    await this.sendToCarOwners(event.carId, {
+      type: event.type,
+      carCode: event.carCode,
+      title: event.title,
+      body: event.body,
+    });
+  }
+
+  @OnEvent('car.rating')
+  async onCarRating(event: CarNotificationEvent): Promise<void> {
+    await this.sendToCarOwners(event.carId, {
+      type: event.type,
+      carCode: event.carCode,
+      title: event.title,
+      body: event.body,
+    });
+  }
+
+  @OnEvent('car.call')
+  async onCarCall(event: CarNotificationEvent): Promise<void> {
+    await this.sendToCarOwners(event.carId, {
+      type: event.type,
+      carCode: event.carCode,
+      title: event.title,
+      body: event.body,
+    });
+  }
+
+  private async sendToCarOwners(carId: number, payload: PushPayload): Promise<void> {
+    const car = await this.carRepository.findOne({ where: { id: carId } });
+    if (!car) return;
+
+    const carDrivers = await this.carDriverRepository.find({ where: { car: { id: carId } } });
+    const userIds = [car.ownerId, ...carDrivers.map((cd) => cd.driverId)];
+
+    const subscriptions = await this.pushSubscriptionRepository.find({
+      where: { userId: In(userIds) },
+    });
+
+    const payloadStr = JSON.stringify(payload);
+
+    await Promise.allSettled(
+      subscriptions.map(async (sub) => {
+        try {
+          await webpush.sendNotification(
+            { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+            payloadStr,
+          );
+        } catch (err: any) {
+          if (err?.statusCode === 410 || err?.statusCode === 404) {
+            await this.pushSubscriptionRepository.delete({ id: sub.id });
+          } else {
+            this.logger.warn(`Push send failed for subscription ${sub.id}: ${err?.message}`);
+          }
+        }
+      }),
+    );
+  }
+}

--- a/packages/shared/src/notification/notification.api.ts
+++ b/packages/shared/src/notification/notification.api.ts
@@ -1,0 +1,23 @@
+import { APIRoutes, apiInfo } from '../api-routes';
+import { PushSubscribeBody, PushUnsubscribeBody } from './notification.types';
+
+export interface NotificationApi {
+  vapidPublicKey(...args: any[]): Promise<{ publicKey: string }>;
+  subscribe(body: PushSubscribeBody, ...args: any[]): Promise<void>;
+  unsubscribe(body: PushUnsubscribeBody, ...args: any[]): Promise<void>;
+}
+
+const NOTIFICATION_ROUTES: APIRoutes<NotificationApi> = {
+  vapidPublicKey: 'vapid-public-key',
+  subscribe: {
+    path: 'subscribe',
+    method: 'POST',
+  },
+  unsubscribe: {
+    path: 'unsubscribe',
+    method: 'POST',
+  },
+};
+
+const NOTIFICATION_API = apiInfo(NOTIFICATION_ROUTES, 'notifications');
+export default NOTIFICATION_API;

--- a/packages/shared/src/notification/notification.types.ts
+++ b/packages/shared/src/notification/notification.types.ts
@@ -1,0 +1,29 @@
+export interface PushSubscribeBody {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+export interface PushUnsubscribeBody {
+  endpoint: string;
+}
+
+export type CarNotificationType = 'message' | 'rating' | 'call';
+
+export interface CarNotificationEvent {
+  type: CarNotificationType;
+  carId: number;
+  carCode: string;
+  carNo: string;
+  title: string;
+  body: string;
+}
+
+export interface PushPayload {
+  type: CarNotificationType;
+  carCode: string;
+  title: string;
+  body: string;
+}

--- a/packages/web/public/service-worker.js
+++ b/packages/web/public/service-worker.js
@@ -1,0 +1,40 @@
+self.addEventListener('push', function (event) {
+  if (!event.data) return;
+
+  const payload = event.data.json();
+  const { type, carCode, title, body } = payload;
+
+  const actions =
+    type === 'message'
+      ? [{ action: 'reply', title: 'Ответить' }]
+      : [{ action: 'open', title: 'Открыть' }];
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: '/logo-for-qr-light.png',
+      badge: '/logo-for-qr-light.png',
+      data: { type, carCode },
+      actions,
+    })
+  );
+});
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+
+  const { type, carCode } = event.notification.data || {};
+  const url = type === 'message' && carCode ? `/g/${carCode}/chat` : '/panel';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (list) {
+      const existing = list.find(function (c) {
+        return c.url.includes(url);
+      });
+      if (existing) {
+        return existing.focus();
+      }
+      return self.clients.openWindow(url);
+    })
+  );
+});

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ProvidersContainer } from '@/components/ProvidersContainer/ProvidersCon
 import { Navigation } from '@/components/Navigation';
 import { InitWebApp } from '@/components/InitWebApp';
 import { AuthProvider } from '@/context/Auth/Auth.context';
+import { NotificationsInit } from '@/components/NotificationsInit/notifications-init';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -80,6 +81,7 @@ export default function RootLayout({
         <StyledComponentsRegistry>
           <ProvidersContainer>
             <AuthProvider>
+              <NotificationsInit />
               <Navigation>{children}</Navigation>
             </AuthProvider>
           </ProvidersContainer>

--- a/packages/web/src/components/NotificationsInit/notifications-init.tsx
+++ b/packages/web/src/components/NotificationsInit/notifications-init.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useContext } from 'react';
+import { AuthContext } from '@/context/Auth/Auth.context';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
+
+function PushNotificationsSubscriber() {
+  usePushNotifications();
+  return null;
+}
+
+export function NotificationsInit() {
+  const { user } = useContext(AuthContext);
+
+  if (!user) return null;
+
+  return <PushNotificationsSubscriber />;
+}

--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -7,7 +7,7 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = atob(base64);
-  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+  return Uint8Array.from([...rawData].map(c => c.charCodeAt(0)));
 }
 
 export function usePushNotifications() {
@@ -30,7 +30,7 @@ export function usePushNotifications() {
         existing ??
         (await registration.pushManager.subscribe({
           userVisibleOnly: true,
-          applicationServerKey,
+          applicationServerKey
         }));
 
       const { endpoint, keys } = subscription.toJSON() as {

--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+import { notificationService } from '@/services';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}
+
+export function usePushNotifications() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+    async function init() {
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return;
+
+      const registration = await navigator.serviceWorker.register('/service-worker.js');
+      await navigator.serviceWorker.ready;
+
+      const { publicKey } = await notificationService.vapidPublicKey();
+      const applicationServerKey = urlBase64ToUint8Array(publicKey);
+
+      const existing = await registration.pushManager.getSubscription();
+      const subscription =
+        existing ??
+        (await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey,
+        }));
+
+      const { endpoint, keys } = subscription.toJSON() as {
+        endpoint: string;
+        keys: { p256dh: string; auth: string };
+      };
+
+      await notificationService.subscribe({ endpoint, keys });
+    }
+
+    init().catch(() => {});
+  }, []);
+}

--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -7,8 +7,10 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = atob(base64);
-  return Uint8Array.from([...rawData].map(c => c.charCodeAt(0)));
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
 }
+
+const SESSION_KEY = 'push-permission-asked';
 
 export function usePushNotifications() {
   useEffect(() => {
@@ -16,7 +18,14 @@ export function usePushNotifications() {
     if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
 
     async function init() {
-      const permission = await Notification.requestPermission();
+      let permission = Notification.permission;
+
+      if (permission === 'default') {
+        if (sessionStorage.getItem(SESSION_KEY)) return;
+        sessionStorage.setItem(SESSION_KEY, '1');
+        permission = await Notification.requestPermission();
+      }
+
       if (permission !== 'granted') return;
 
       const registration = await navigator.serviceWorker.register('/service-worker.js');
@@ -30,7 +39,7 @@ export function usePushNotifications() {
         existing ??
         (await registration.pushManager.subscribe({
           userVisibleOnly: true,
-          applicationServerKey
+          applicationServerKey,
         }));
 
       const { endpoint, keys } = subscription.toJSON() as {

--- a/packages/web/src/services/index.ts
+++ b/packages/web/src/services/index.ts
@@ -3,13 +3,15 @@ import AUTH_API from '@shared/auth/auth.api';
 import CAR_API from '@shared/car/car.api';
 import FILE_API from '@shared/file/file.api';
 import { USER_API } from '@shared/user/user.api';
+import NOTIFICATION_API from '@shared/notification/notification.api';
 
 export const createApi = (userToken?: string) => {
   return {
     auth: createApiService(AUTH_API, userToken),
     car: createApiService(CAR_API, userToken),
     file: createApiService(FILE_API, userToken),
-    user: createApiService(USER_API, userToken)
+    user: createApiService(USER_API, userToken),
+    notification: createApiService(NOTIFICATION_API, userToken)
   };
 };
 
@@ -19,3 +21,4 @@ export const authService = api.auth;
 export const carService = api.car;
 export const fileService = api.file;
 export const userService = api.user;
+export const notificationService = api.notification;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds Web Push API + Service Worker browser notifications for three events: new message, new rating, driver call
- Permission dialog is shown once per session (sessionStorage) for authenticated users; if already granted, subscription is silently refreshed every session
- Message notifications include a "Reply" action button that opens `/g/{carCode}/chat`
- Call/rating notifications open `/panel` on click
- Push subscriptions stored in `push_subscriptions` table (TypeORM synchronize)
- VAPID keys configured via `config.yaml`

## Changes

- `packages/backend`: new `PushSubscription` entity, `NotificationModule` (service + controller), VAPID config, `car.service.ts` emits `car.call` / `car.rating` / `car.message` events
- `packages/shared`: `notification.types.ts`, `notification.api.ts`
- `packages/web`: `service-worker.js`, `usePushNotifications` hook (sessionStorage-gated permission request), `NotificationsInit` component, wired into layout

## Test plan

- [ ] Generate VAPID keys: `npx web-push generate-vapid-keys`
- [ ] Add to server `config-backend.yaml` under `vapid:` section
- [ ] Restart backend (TypeORM will auto-create `push_subscriptions` table)
- [ ] Log in → open panel → browser asks for notification permission
- [ ] Grant permission → subscription saved
- [ ] From another browser/incognito: send message, rate car, press "Call driver"
- [ ] Verify push notifications arrive; message notification has "Reply" button → opens chat

https://claude.ai/code/session_014oYBXcwSG9PFMVxT6B4zMA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oYBXcwSG9PFMVxT6B4zMA)_