### PR TITLE
fix: project-level Serena MCP and superpowers marketplace for web sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,15 @@
       }
     ]
   },
+  "enableAllProjectMcpServers": true,
+  "extraKnownMarketplaces": {
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
+    }
+  },
   "enabledPlugins": {
     "superpowers@superpowers-marketplace": true
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena-mcp-server",
+        "--context",
+        "ide-assistant",
+        "--project-root",
+        "/home/user/beznomera"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Проблема

В новых веб-сессиях (мобильный/браузер) глобальные настройки (`~/.claude.json`, `~/.claude/settings.json`) не сохраняются между контейнерами, поэтому superpowers и Serena MCP не работали.

## Изменения

- **`.mcp.json`** — Serena MCP на уровне проекта (`uvx serena-mcp-server`), автоматически подключается в каждой сессии
- **`.claude/settings.json`**:
  - `enableAllProjectMcpServers: true` — авто-апрув MCP из `.mcp.json` без диалога
  - `extraKnownMarketplaces` — регистрирует `superpowers-marketplace` (GitHub: obra/superpowers-marketplace) для всех сессий
  - `enabledPlugins` — включает superpowers на уровне проекта

## Проверка

- [ ] Открыть новую сессию на mobile/web → `/superpowers:brainstorming` должен работать
- [ ] Serena MCP инициализируется автоматически (без ручного апрува)

https://claude.ai/code/session_01Mu7oX27DLdvXkQcZUv2W8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu7oX27DLdvXkQcZUv2W8C)_