### PR TITLE
fix: explicitly install superpowers and Serena MCP in session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,6 +9,13 @@ echo '{"async": true, "asyncTimeout": 300000}'
 
 cd "$CLAUDE_PROJECT_DIR"
 
+echo "[session-start] Installing plugins..."
+claude plugin marketplace add obra/superpowers-marketplace 2>&1 || true
+claude plugin install superpowers@superpowers-marketplace --scope project 2>&1 || true
+
+echo "[session-start] Installing Serena MCP..."
+claude mcp add serena --scope user -- uvx --from git+https://github.com/oraios/serena serena-mcp-server --context ide-assistant --project-root "$CLAUDE_PROJECT_DIR" 2>&1 || true
+
 echo "[session-start] Installing root dependencies..."
 npm install --legacy-peer-deps --prefer-offline 2>&1
 


### PR DESCRIPTION
## Проблема

`enabledPlugins` в `settings.json` активирует плагин, но не скачивает его в новый контейнер. В свежих веб-сессиях кеш пустой → `/superpowers:brainstorming` даёт "Unknown command".

## Решение

Добавил в `session-start.sh` явные команды при старте каждой удалённой сессии:

```bash
claude plugin marketplace add obra/superpowers-marketplace
claude plugin install superpowers@superpowers-marketplace --scope project
claude mcp add serena --scope user -- uvx ... serena-mcp-server ...
```

Если уже установлено — команды завершаются с `|| true` без ошибки.

## Проверка

Hook протестирован локально — idempotent, всё отрабатывает без ошибок.

https://claude.ai/code/session_01Mu7oX27DLdvXkQcZUv2W8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu7oX27DLdvXkQcZUv2W8C)_