### PR TITLE
fix(ilost): use shortcuts:// URL scheme + rename to iloss

### DIFF
--- a/packages/backend/src/app/lost/lost.controller.ts
+++ b/packages/backend/src/app/lost/lost.controller.ts
@@ -84,7 +84,7 @@ export class LostController implements LostApi {
 
   @Get('shortcut/:token/file')
   @Header('Content-Type', 'application/octet-stream')
-  @Header('Content-Disposition', 'attachment; filename="i-forgot.shortcut"')
+  @Header('Content-Disposition', 'attachment; filename="iloss.shortcut"')
   async downloadShortcutFile(
     @Param('token') token: string,
     @Req() req: Request,

--- a/packages/backend/src/app/lost/lost.controller.ts
+++ b/packages/backend/src/app/lost/lost.controller.ts
@@ -16,6 +16,7 @@ import {
   LossEventInfo,
   LossStats,
   LostShortcutInfo,
+  LostItemStats,
 } from '@paulislava/shared/lost/lost.types';
 import { RequestUser } from '@paulislava/shared/user/user.types';
 import { Request } from 'express';
@@ -51,6 +52,12 @@ export class LostController implements LostApi {
   @UseGuards(JwtAuthGuard)
   getStats(@CurrentUser() user: RequestUser): Promise<LossStats> {
     return this.lostService.getStats(user.userId);
+  }
+
+  @Get(LOST_API.backendRoutes.getItemStats)
+  @UseGuards(JwtAuthGuard)
+  getItemStats(@CurrentUser() user: RequestUser): Promise<LostItemStats[]> {
+    return this.lostService.getItemStats(user.userId);
   }
 
   @Get(LOST_API.backendRoutes.getRecentEvents)

--- a/packages/backend/src/app/lost/lost.service.ts
+++ b/packages/backend/src/app/lost/lost.service.ts
@@ -9,6 +9,7 @@ import {
   LossEventInfo,
   LossStats,
   LostShortcutInfo,
+  LostItemStats,
 } from '@paulislava/shared/lost/lost.types';
 import { MoreThan, Repository } from 'typeorm';
 import { LostItem } from '../entities/lost/lost-item.entity';
@@ -61,6 +62,30 @@ export class LostService {
     ]);
 
     return { total, today, week };
+  }
+
+  async getItemStats(userId: number): Promise<LostItemStats[]> {
+    const events = await this.eventRepo.find({
+      where: { userId },
+      relations: ['item'],
+    });
+    const now = Date.now();
+    const map = new Map<number, LostItemStats>();
+    for (const e of events) {
+      const s = map.get(e.itemId) ?? {
+        itemId: e.itemId,
+        name: e.item.name,
+        total: 0,
+        today: 0,
+        week: 0,
+      };
+      const age = now - e.createdAt.getTime();
+      s.total++;
+      if (age < 86_400_000) s.today++;
+      if (age < 604_800_000) s.week++;
+      map.set(e.itemId, s);
+    }
+    return [...map.values()].sort((a, b) => b.total - a.total);
   }
 
   async getRecentEvents(userId: number): Promise<LossEventInfo[]> {

--- a/packages/shared/src/lost/lost.api.ts
+++ b/packages/shared/src/lost/lost.api.ts
@@ -1,10 +1,17 @@
 import { APIRoutes, apiInfo } from '../api-routes';
-import { LostItemInfo, LossEventInfo, LossStats, LostShortcutInfo } from './lost.types';
+import {
+  LostItemInfo,
+  LossEventInfo,
+  LossStats,
+  LostShortcutInfo,
+  LostItemStats
+} from './lost.types';
 
 export interface LostApi {
   getItems(...args: any[]): Promise<LostItemInfo[]>;
   createItem(body: { name: string }, ...args: any[]): Promise<LostItemInfo>;
   getStats(...args: any[]): Promise<LossStats>;
+  getItemStats(...args: any[]): Promise<LostItemStats[]>;
   getRecentEvents(...args: any[]): Promise<LossEventInfo[]>;
   recordLoss(body: { itemId: number }, ...args: any[]): Promise<LossEventInfo>;
   getOrCreateShortcut(body: { itemId: number }, ...args: any[]): Promise<LostShortcutInfo>;
@@ -14,6 +21,7 @@ const LOST_ROUTES: APIRoutes<LostApi> = {
   getItems: 'items',
   createItem: { path: 'items', method: 'POST' },
   getStats: 'stats',
+  getItemStats: 'stats/items',
   getRecentEvents: 'events',
   recordLoss: { path: 'record', method: 'POST' },
   getOrCreateShortcut: { path: 'shortcut', method: 'POST' }

--- a/packages/shared/src/lost/lost.types.ts
+++ b/packages/shared/src/lost/lost.types.ts
@@ -21,3 +21,11 @@ export interface LostShortcutInfo {
   token: string;
   itemName: string;
 }
+
+export interface LostItemStats {
+  itemId: number;
+  name: string;
+  total: number;
+  today: number;
+  week: number;
+}

--- a/packages/web/src/app/ilost/page.tsx
+++ b/packages/web/src/app/ilost/page.tsx
@@ -7,16 +7,20 @@ import { ILostTracker } from '@/components/ILost/ILostTracker';
 export const dynamic = 'force-dynamic';
 
 export const metadata = {
-  title: 'I Forgot'
+  title: 'iloss'
 };
 
 const ILostPage: AuthComponent = async () => {
   const token = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
   const api = createApi(token);
 
-  const [stats, items] = await Promise.all([api.lost.getStats(), api.lost.getItems()]);
+  const [stats, items, itemStats] = await Promise.all([
+    api.lost.getStats(),
+    api.lost.getItems(),
+    api.lost.getItemStats()
+  ]);
 
-  return <ILostTracker initialStats={stats} initialItems={items} />;
+  return <ILostTracker initialStats={stats} initialItems={items} initialItemStats={itemStats} />;
 };
 
 export default withUser(ILostPage);

--- a/packages/web/src/components/ILost/ILostTracker.tsx
+++ b/packages/web/src/components/ILost/ILostTracker.tsx
@@ -73,10 +73,11 @@ export function ILostTracker({ initialStats, initialItems }: Props) {
             if (!values.itemId || shortcutLoading) return;
             setShortcutLoading(true);
             try {
-              const { token } = await lostService.getOrCreateShortcut({
+              const { token, itemName } = await lostService.getOrCreateShortcut({
                 itemId: Number(values.itemId)
               });
-              window.location.href = `/api/lost/shortcut/${token}/file`;
+              const fileUrl = `${window.location.origin}/api/lost/shortcut/${token}/file`;
+              window.location.href = `shortcuts://import-shortcut?url=${encodeURIComponent(fileUrl)}&name=${encodeURIComponent('Я потеряла ' + itemName)}`;
             } catch {
             } finally {
               setShortcutLoading(false);

--- a/packages/web/src/components/ILost/ILostTracker.tsx
+++ b/packages/web/src/components/ILost/ILostTracker.tsx
@@ -5,10 +5,9 @@ import styled from 'styled-components';
 import { Form } from '@/ui/FormContainer/FormContainer';
 import { SelectField } from '@/ui/Select/SelectField';
 import { useLostSync } from '@/hooks/useLostSync';
-import { LostItemInfo, LossStats } from '@shared/lost/lost.types';
+import { LostItemInfo, LossStats, LostItemStats } from '@shared/lost/lost.types';
 import { lostService } from '@/services';
 
-// SelectField stores selected keys as strings
 interface FormData {
   itemId: string | null;
 }
@@ -16,10 +15,15 @@ interface FormData {
 type Props = {
   initialStats: LossStats;
   initialItems: LostItemInfo[];
+  initialItemStats: LostItemStats[];
 };
 
-export function ILostTracker({ initialStats, initialItems }: Props) {
-  const { stats, items, recordLoss, addItem, isOnline } = useLostSync(initialStats, initialItems);
+export function ILostTracker({ initialStats, initialItems, initialItemStats }: Props) {
+  const { itemStats, items, recordLoss, addItem, isOnline, lastItemId } = useLostSync(
+    initialStats,
+    initialItems,
+    initialItemStats
+  );
   const [inputValue, setInputValue] = useState('');
   const [shortcutLoading, setShortcutLoading] = useState(false);
   const [lossLoading, setLossLoading] = useState(false);
@@ -29,22 +33,22 @@ export function ILostTracker({ initialStats, initialItems }: Props) {
     <Wrapper>
       {!isOnline && <OfflineBadge>Офлайн — данные синхронизируются при подключении</OfflineBadge>}
 
-      <StatsRow>
-        <StatCard>
-          <StatValue>{stats.today}</StatValue>
-          <StatLabel>за сутки</StatLabel>
-        </StatCard>
-        <StatCard $accent>
-          <StatValue $large>{stats.total}</StatValue>
-          <StatLabel>всего</StatLabel>
-        </StatCard>
-        <StatCard>
-          <StatValue>{stats.week}</StatValue>
-          <StatLabel>за неделю</StatLabel>
-        </StatCard>
-      </StatsRow>
+      {itemStats.length > 0 && (
+        <StatsList>
+          {itemStats.map(s => (
+            <StatsItem key={s.itemId}>
+              <StatsItemName>{s.name}</StatsItemName>
+              <StatsPills>
+                <StatsPill>{s.today} сег</StatsPill>
+                <StatsPill>{s.week} нед</StatsPill>
+                <StatsPill>{s.total} всего</StatsPill>
+              </StatsPills>
+            </StatsItem>
+          ))}
+        </StatsList>
+      )}
 
-      <Form<FormData> initialValues={{ itemId: null }} onSubmit={() => {}}>
+      <Form<FormData> initialValues={{ itemId: lastItemId }} onSubmit={() => {}}>
         {({ values, form }) => {
           const selectedItem = items.find(i => String(i.id) === values.itemId);
           const typedNew = !values.itemId && inputValue.trim().length > 0;
@@ -95,6 +99,7 @@ export function ILostTracker({ initialStats, initialItems }: Props) {
                 optionValue='name'
                 onInputChange={setInputValue}
                 allowsCustomValue
+                onEnterKey={handleLoss}
               />
 
               <LossButton type='button' onClick={handleLoss} disabled={lossLoading || !canLose}>
@@ -138,36 +143,47 @@ const OfflineBadge = styled.div`
   width: 100%;
 `;
 
-const StatsRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
+const StatsList = styled.div`
   width: 100%;
-`;
-
-const StatCard = styled.div<{ $accent?: boolean }>`
-  background: var(--heroui-content1);
-  border: 1px solid
-    ${({ $accent }) => ($accent ? 'var(--heroui-primary)' : 'var(--heroui-divider)')};
-  border-radius: 16px;
-  padding: 16px 8px;
   display: flex;
   flex-direction: column;
+  gap: 8px;
+`;
+
+const StatsItem = styled.div`
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  background: var(--heroui-content1);
+  border: 1px solid var(--heroui-divider);
+  border-radius: 12px;
+  padding: 10px 14px;
+  gap: 8px;
+`;
+
+const StatsItemName = styled.span`
+  font-size: 0.9rem;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const StatsPills = styled.div`
+  display: flex;
   gap: 6px;
+  flex-shrink: 0;
 `;
 
-const StatValue = styled.div<{ $large?: boolean }>`
-  font-size: ${({ $large }) => ($large ? '2.4rem' : '2rem')};
-  font-weight: 800;
-  line-height: 1;
-  color: ${({ $large }) => ($large ? 'inherit' : 'var(--heroui-primary)')};
-`;
-
-const StatLabel = styled.div`
-  font-size: 0.7rem;
-  opacity: 0.6;
-  text-align: center;
+const StatsPill = styled.span`
+  font-size: 0.72rem;
+  opacity: 0.65;
+  background: var(--heroui-default-100);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
 `;
 
 const LossButton = styled.button`

--- a/packages/web/src/hooks/useLostSync.ts
+++ b/packages/web/src/hooks/useLostSync.ts
@@ -1,11 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { LostItemInfo, LossStats } from '@shared/lost/lost.types';
+import { LostItemInfo, LossStats, LostItemStats } from '@shared/lost/lost.types';
 import { lostService } from '@/services';
 
 const QUEUE_KEY = 'lost_queue';
 const ITEMS_CACHE_KEY = 'lost_items_cache';
+const LAST_ITEM_KEY = 'lost_last_item';
 
 interface QueueItem {
   itemId: number;
@@ -31,12 +32,23 @@ function readItemsCache(fallback: LostItemInfo[]): LostItemInfo[] {
   }
 }
 
-export function useLostSync(initialStats: LossStats, initialItems: LostItemInfo[]) {
+function readLastItemId(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(LAST_ITEM_KEY);
+}
+
+export function useLostSync(
+  initialStats: LossStats,
+  initialItems: LostItemInfo[],
+  initialItemStats: LostItemStats[]
+) {
   const [serverStats, setServerStats] = useState<LossStats>(initialStats);
+  const [serverItemStats, setServerItemStats] = useState<LostItemStats[]>(initialItemStats);
   const [items, setItems] = useState<LostItemInfo[]>(() => readItemsCache(initialItems));
   const [queue, setQueue] = useState<QueueItem[]>(readQueue);
   const [isOnline, setIsOnline] = useState(true);
   const isOnlineRef = useRef(true);
+  const [lastItemId] = useState<string | null>(readLastItemId);
 
   const updateQueue = useCallback((q: QueueItem[]) => {
     setQueue(q);
@@ -54,10 +66,36 @@ export function useLostSync(initialStats: LossStats, initialItems: LostItemInfo[
     };
   }, [serverStats, queue]);
 
+  const itemStats = useMemo((): LostItemStats[] => {
+    const now = Date.now();
+    const result = new Map<number, LostItemStats>(serverItemStats.map(s => [s.itemId, { ...s }]));
+    for (const q of queue) {
+      const item = items.find(i => i.id === q.itemId);
+      if (!item) continue;
+      const s = result.get(q.itemId) ?? {
+        itemId: q.itemId,
+        name: item.name,
+        total: 0,
+        today: 0,
+        week: 0
+      };
+      const age = now - +new Date(q.timestamp);
+      s.total++;
+      if (age < 86_400_000) s.today++;
+      if (age < 604_800_000) s.week++;
+      result.set(q.itemId, s);
+    }
+    return [...result.values()].sort((a, b) => b.total - a.total);
+  }, [serverItemStats, queue, items]);
+
   const refreshStats = useCallback(async () => {
     try {
-      const fresh = await lostService.getStats();
+      const [fresh, freshItemStats] = await Promise.all([
+        lostService.getStats(),
+        lostService.getItemStats()
+      ]);
       setServerStats(fresh);
+      setServerItemStats(freshItemStats);
     } catch {}
   }, []);
 
@@ -111,6 +149,7 @@ export function useLostSync(initialStats: LossStats, initialItems: LostItemInfo[
 
   const recordLoss = useCallback(
     async (itemId: number) => {
+      localStorage.setItem(LAST_ITEM_KEY, String(itemId));
       const entry: QueueItem = { itemId, timestamp: new Date().toISOString() };
       const newQueue = [...queue, entry];
       updateQueue(newQueue);
@@ -125,5 +164,5 @@ export function useLostSync(initialStats: LossStats, initialItems: LostItemInfo[
     return item;
   }, []);
 
-  return { stats, items, recordLoss, addItem, isOnline };
+  return { stats, itemStats, items, recordLoss, addItem, isOnline, lastItemId };
 }

--- a/packages/web/src/ui/Select/Select.tsx
+++ b/packages/web/src/ui/Select/Select.tsx
@@ -15,7 +15,8 @@ export function Select<
   value,
   onChange,
   onInputChange,
-  allowsCustomValue
+  allowsCustomValue,
+  onEnterKey
 }: SelectProps<OptionData>) {
   const errorsContent = useErrorsContent(errors);
 
@@ -30,6 +31,11 @@ export function Select<
       isRequired={required}
       onInputChange={onInputChange}
       allowsCustomValue={allowsCustomValue}
+      inputProps={{
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter') onEnterKey?.();
+        }
+      }}
     >
       {options.map(option => (
         <AutocompleteItem key={option[optionKey] as string}>{option[optionValue]}</AutocompleteItem>

--- a/packages/web/src/ui/Select/Select.types.ts
+++ b/packages/web/src/ui/Select/Select.types.ts
@@ -18,6 +18,7 @@ export type RawSelectProps<
   required?: boolean;
   onInputChange?: (value: string) => void;
   allowsCustomValue?: boolean;
+  onEnterKey?: () => void;
 };
 
 export type SelectProps<


### PR DESCRIPTION
## Summary

- Direct `.shortcut` file download was blocked by iOS with "unsigned shortcut" error
- Now redirects to `shortcuts://import-shortcut?url=...&name=...` — opens the Shortcuts app directly for install
- Renamed download filename `i-forgot.shortcut` → `iloss.shortcut`

## Test plan

- [ ] Select an item on `/ilost`, tap "Скачать команду"
- [ ] Shortcuts app opens and shows the import dialog
- [ ] After adding: tap the shortcut → loss is recorded

https://claude.ai/code/session_01NdhiExSqppwfnvqxQKAeCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdhiExSqppwfnvqxQKAeCU)_