### PR TITLE
fix(ilost): nginx exception for public shortcut endpoints

### DIFF
--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -14,6 +14,11 @@ location /socket.io {
         proxy_buffering off;
 }
 
+location ~ ^/api/lost/shortcut/ {
+        auth_basic off;
+        proxy_pass http://0.0.0.0:3000;
+}
+
 location /api {
         proxy_pass http://0.0.0.0:3000;
 }

--- a/packages/web/src/components/ILost/ILostTracker.tsx
+++ b/packages/web/src/components/ILost/ILostTracker.tsx
@@ -81,7 +81,7 @@ export function ILostTracker({ initialStats, initialItems, initialItemStats }: P
                 itemId: Number(values.itemId)
               });
               const fileUrl = `${window.location.origin}/api/lost/shortcut/${token}/file`;
-              window.location.href = `shortcuts://import-shortcut?url=${encodeURIComponent(fileUrl)}&name=${encodeURIComponent('Я потеряла ' + itemName)}`;
+              window.location.href = `shortcuts://import-shortcut?url=${encodeURIComponent(fileUrl)}&name=${encodeURIComponent('iloss ' + itemName)}`;
             } catch {
             } finally {
               setShortcutLoading(false);


### PR DESCRIPTION
## Summary

Root cause of "Указанный URL быстрой команды недействителен": nginx had an `auth_basic` rule that blocked requests without a session cookie. The Shortcuts app makes requests without a browser cookie, so the `/api/lost/shortcut/` endpoints were blocked.

- Added `location ~ ^/api/lost/shortcut/` with `auth_basic off` before the generic `/api` block
- Simplified shortcut name to `iloss <itemName>` (ASCII-safe) to avoid URL encoding issues

## Test plan

- [ ] Select an item on `/ilost`, tap "Скачать команду"
- [ ] Shortcuts app opens and shows the import dialog
- [ ] Add shortcut → tap it → loss is recorded without opening the app

https://claude.ai/code/session_01NdhiExSqppwfnvqxQKAeCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdhiExSqppwfnvqxQKAeCU)_