### PR TITLE
fix(profile): catch getProfile error, fallback to /me

### DIFF
--- a/packages/web/src/app/profile/ProfileClient.tsx
+++ b/packages/web/src/app/profile/ProfileClient.tsx
@@ -326,7 +326,7 @@ function ProfileContent({ initialProfile }: { initialProfile: UserProfile }) {
         <LinkedAccountsSection accounts={profile.linkedAccounts ?? []} onUnlink={handleUnlink} />
       </section>
 
-      {permission !== 'unsupported' && (
+      {permission !== null && (
         <section className='space-y-3'>
           <h2 className='text-lg font-semibold'>Уведомления</h2>
           <div className='flex items-center justify-between gap-3'>
@@ -338,6 +338,10 @@ function ProfileContent({ initialProfile }: { initialProfile: UserProfile }) {
             ) : permission === 'denied' ? (
               <Chip color='danger' variant='flat' size='sm'>
                 Заблокированы
+              </Chip>
+            ) : permission === 'unsupported' ? (
+              <Chip color='warning' variant='flat' size='sm'>
+                Не поддерживается
               </Chip>
             ) : (
               <div className='flex items-center gap-2'>
@@ -352,6 +356,11 @@ function ProfileContent({ initialProfile }: { initialProfile: UserProfile }) {
           </div>
           {permission === 'denied' && (
             <p className='text-xs text-default-400'>Разрешите уведомления в настройках браузера</p>
+          )}
+          {permission === 'unsupported' && (
+            <p className='text-xs text-default-400'>
+              Добавьте сайт на главный экран для получения уведомлений
+            </p>
           )}
         </section>
       )}

--- a/packages/web/src/app/profile/page.tsx
+++ b/packages/web/src/app/profile/page.tsx
@@ -3,12 +3,20 @@ import { createApi } from '@/services';
 import { AUTH_COOKIE_NAME } from '@/helpers/constants';
 import { cookies } from 'next/headers';
 import { ProfileClient } from './ProfileClient';
+import { UserProfile } from '@shared/user/user.types';
 
 const ProfilePage: AuthComponent = async ({ user }) => {
   const cookieStore = await cookies();
   const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
   const api = createApi(token);
-  const profile = await api.user.getProfile(user.userId);
+
+  let profile: UserProfile;
+  try {
+    profile = await api.user.getProfile(user.userId);
+  } catch (e) {
+    console.error('getProfile failed, falling back to /me:', e);
+    profile = await api.user.me();
+  }
 
   return <ProfileClient initialProfile={profile} />;
 };

--- a/packages/web/src/hooks/usePushNotifications.ts
+++ b/packages/web/src/hooks/usePushNotifications.ts
@@ -37,7 +37,7 @@ async function subscribeAfterPermission() {
 
 export function usePushNotifications() {
   const [showBanner, setShowBanner] = useState(false);
-  const [permission, setPermission] = useState<NotificationPermission | 'unsupported'>('default');
+  const [permission, setPermission] = useState<NotificationPermission | 'unsupported' | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
## Summary

- Оборачивает `getProfile` в try/catch — если endpoint возвращает ошибку, fallback на `/user/me`
- Предотвращает SSR crash и экран "Application error"
- Реальная причина ошибки будет видна в логах сервера (`console.error`)

## Пустые чаты

Скорее всего связано с тем, что CI runner не запустился при мёрдже PR #52, и backend не был передеплоен. Нужно проверить логи сервера и состояние деплоя.

https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UicaxwDnt2tnoGVXsMrWQz)_