### PR TITLE
Add live log viewer for phone browser

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { ChatModule } from './app/chat/chat.module';
 import { AdminModule } from './app/admin/admin.module';
 import { NotificationModule } from './app/notification/notification.module';
 import { LostModule } from './app/lost/lost.module';
+import { LogsModule } from './app/logging/logs.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { LostModule } from './app/lost/lost.module';
     AdminModule,
     NotificationModule,
     LostModule,
+    LogsModule,
   ],
   controllers: [AppController, HealthController],
   providers: [AppService],

--- a/packages/backend/src/app/logging/log-buffer.service.ts
+++ b/packages/backend/src/app/logging/log-buffer.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter } from 'events';
+import { LogEntry, logEvents, getLogHistory } from './log-buffer';
+
+@Injectable()
+export class LogBufferService {
+  readonly events: EventEmitter = logEvents;
+
+  getHistory(): LogEntry[] {
+    return getLogHistory();
+  }
+}

--- a/packages/backend/src/app/logging/log-buffer.ts
+++ b/packages/backend/src/app/logging/log-buffer.ts
@@ -1,0 +1,24 @@
+import { EventEmitter } from 'events';
+
+export interface LogEntry {
+  time: number;
+  message: string;
+}
+
+const MAX_BUFFER = 500;
+const buffer: LogEntry[] = [];
+export const logEvents = new EventEmitter();
+logEvents.setMaxListeners(100);
+
+export function pushLog(message: string): void {
+  const trimmed = message.trimEnd();
+  if (!trimmed) return;
+  const entry: LogEntry = { time: Date.now(), message: trimmed };
+  buffer.push(entry);
+  if (buffer.length > MAX_BUFFER) buffer.shift();
+  logEvents.emit('log', entry);
+}
+
+export function getLogHistory(): LogEntry[] {
+  return [...buffer];
+}

--- a/packages/backend/src/app/logging/logs.controller.ts
+++ b/packages/backend/src/app/logging/logs.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import type { Response } from 'express';
+import { ApiClientAuthGuard } from '../auth/api-auth.guard';
+import { LogBufferService } from './log-buffer.service';
+import type { LogEntry } from './log-buffer';
+
+@Controller('logs')
+@UseGuards(ApiClientAuthGuard)
+export class LogsController {
+  constructor(private readonly logBuffer: LogBufferService) {}
+
+  @Get()
+  getHistory(): LogEntry[] {
+    return this.logBuffer.getHistory();
+  }
+
+  @Get('stream')
+  stream(@Res() res: Response): void {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    for (const entry of this.logBuffer.getHistory()) {
+      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    }
+
+    const onLog = (entry: LogEntry): void => {
+      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    };
+
+    this.logBuffer.events.on('log', onLog);
+    res.on('close', () => this.logBuffer.events.off('log', onLog));
+  }
+}

--- a/packages/backend/src/app/logging/logs.module.ts
+++ b/packages/backend/src/app/logging/logs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LogsController } from './logs.controller';
+import { LogBufferService } from './log-buffer.service';
+
+@Module({
+  providers: [LogBufferService],
+  controllers: [LogsController],
+  exports: [LogBufferService],
+})
+export class LogsModule {}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -4,6 +4,20 @@ import { addAlias } from 'module-alias';
 
 addAlias('~', __dirname);
 
+import { pushLog } from './app/logging/log-buffer';
+
+const _origStdoutWrite = process.stdout.write.bind(process.stdout);
+(process.stdout as any).write = (chunk: any, ...args: any[]): boolean => {
+  if (chunk) pushLog(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+  return _origStdoutWrite(chunk, ...args);
+};
+
+const _origStderrWrite = process.stderr.write.bind(process.stderr);
+(process.stderr as any).write = (chunk: any, ...args: any[]): boolean => {
+  if (chunk) pushLog(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+  return _origStderrWrite(chunk, ...args);
+};
+
 import { Encoding } from 'crypto';
 import { ServerResponse } from 'http';
 

--- a/packages/web/src/app/admin/logs/log-viewer.tsx
+++ b/packages/web/src/app/admin/logs/log-viewer.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface LogEntry {
+  time: number;
+  message: string;
+}
+
+function getLevel(msg: string): 'error' | 'warn' | 'log' {
+  const l = msg.toLowerCase();
+  if (l.includes('error') || l.includes(' err ')) return 'error';
+  if (l.includes('warn')) return 'warn';
+  return 'log';
+}
+
+const COLORS: Record<ReturnType<typeof getLevel>, string> = {
+  error: '#ff6b6b',
+  warn: '#ffd93d',
+  log: '#c9d1d9',
+};
+
+export function LogViewer() {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  useEffect(() => {
+    const es = new EventSource('/api/logs/stream', { withCredentials: true });
+    es.onmessage = (e: MessageEvent<string>) => {
+      if (pausedRef.current) return;
+      const entry = JSON.parse(e.data) as LogEntry;
+      setLogs((prev) => [...prev.slice(-999), entry]);
+    };
+    return () => es.close();
+  }, []);
+
+  useEffect(() => {
+    if (!paused) bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [logs, paused]);
+
+  return (
+    <div
+      style={{
+        background: '#0d1117',
+        minHeight: '100dvh',
+        padding: '8px',
+        fontFamily: 'monospace',
+        fontSize: '12px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '8px',
+          position: 'sticky',
+          top: 0,
+          background: '#0d1117',
+          padding: '4px 0',
+          zIndex: 1,
+        }}
+      >
+        <span style={{ color: '#8b949e' }}>
+          Logs ({logs.length})
+        </span>
+        <button
+          onClick={() => setPaused((p) => !p)}
+          style={{
+            padding: '4px 12px',
+            background: paused ? '#238636' : '#b62324',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '12px',
+          }}
+        >
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+      </div>
+      <div>
+        {logs.map((entry, i) => (
+          <div key={i} style={{ display: 'flex', gap: '8px', lineHeight: '1.5', wordBreak: 'break-all' }}>
+            <span style={{ color: '#484f58', flexShrink: 0 }}>
+              {new Date(entry.time).toLocaleTimeString()}
+            </span>
+            <span style={{ color: COLORS[getLevel(entry.message)] }}>
+              {entry.message}
+            </span>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/logs/log-viewer.tsx
+++ b/packages/web/src/app/admin/logs/log-viewer.tsx
@@ -17,7 +17,7 @@ function getLevel(msg: string): 'error' | 'warn' | 'log' {
 const COLORS: Record<ReturnType<typeof getLevel>, string> = {
   error: '#ff6b6b',
   warn: '#ffd93d',
-  log: '#c9d1d9',
+  log: '#c9d1d9'
 };
 
 export function LogViewer() {
@@ -35,7 +35,7 @@ export function LogViewer() {
     es.onmessage = (e: MessageEvent<string>) => {
       if (pausedRef.current) return;
       const entry = JSON.parse(e.data) as LogEntry;
-      setLogs((prev) => [...prev.slice(-999), entry]);
+      setLogs(prev => [...prev.slice(-999), entry]);
     };
     return () => es.close();
   }, []);
@@ -51,7 +51,7 @@ export function LogViewer() {
         minHeight: '100dvh',
         padding: '8px',
         fontFamily: 'monospace',
-        fontSize: '12px',
+        fontSize: '12px'
       }}
     >
       <div
@@ -64,14 +64,12 @@ export function LogViewer() {
           top: 0,
           background: '#0d1117',
           padding: '4px 0',
-          zIndex: 1,
+          zIndex: 1
         }}
       >
-        <span style={{ color: '#8b949e' }}>
-          Logs ({logs.length})
-        </span>
+        <span style={{ color: '#8b949e' }}>Logs ({logs.length})</span>
         <button
-          onClick={() => setPaused((p) => !p)}
+          onClick={() => setPaused(p => !p)}
           style={{
             padding: '4px 12px',
             background: paused ? '#238636' : '#b62324',
@@ -79,7 +77,7 @@ export function LogViewer() {
             border: 'none',
             borderRadius: '6px',
             cursor: 'pointer',
-            fontSize: '12px',
+            fontSize: '12px'
           }}
         >
           {paused ? 'Resume' : 'Pause'}
@@ -87,13 +85,14 @@ export function LogViewer() {
       </div>
       <div>
         {logs.map((entry, i) => (
-          <div key={i} style={{ display: 'flex', gap: '8px', lineHeight: '1.5', wordBreak: 'break-all' }}>
+          <div
+            key={i}
+            style={{ display: 'flex', gap: '8px', lineHeight: '1.5', wordBreak: 'break-all' }}
+          >
             <span style={{ color: '#484f58', flexShrink: 0 }}>
               {new Date(entry.time).toLocaleTimeString()}
             </span>
-            <span style={{ color: COLORS[getLevel(entry.message)] }}>
-              {entry.message}
-            </span>
+            <span style={{ color: COLORS[getLevel(entry.message)] }}>{entry.message}</span>
           </div>
         ))}
         <div ref={bottomRef} />

--- a/packages/web/src/app/admin/logs/page.tsx
+++ b/packages/web/src/app/admin/logs/page.tsx
@@ -1,0 +1,8 @@
+import { AuthComponent, withUser } from '@/context/Auth/withUser';
+import { LogViewer } from './log-viewer';
+
+const LogsPage: AuthComponent = () => {
+  return <LogViewer />;
+};
+
+export default withUser(LogsPage, true);

--- a/packages/web/src/app/api/logs/stream/route.ts
+++ b/packages/web/src/app/api/logs/stream/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   }
 
   const upstream = await fetch(`${BACKEND_URL}/logs/stream`, {
-    headers: { Authorization: `Bearer ${BACKEND_API_TOKEN}` },
+    headers: { Authorization: `Bearer ${BACKEND_API_TOKEN}` }
   });
 
   if (!upstream.ok || !upstream.body) {
@@ -23,7 +23,7 @@ export async function GET() {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    },
+      'X-Accel-Buffering': 'no'
+    }
   });
 }

--- a/packages/web/src/app/api/logs/stream/route.ts
+++ b/packages/web/src/app/api/logs/stream/route.ts
@@ -1,0 +1,29 @@
+import { getUserFromRequest } from '@/utils/auth-server';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
+const BACKEND_API_TOKEN = process.env.BACKEND_API_TOKEN ?? '';
+
+export async function GET() {
+  const user = await getUserFromRequest();
+
+  if (!user?.isAdmin) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const upstream = await fetch(`${BACKEND_URL}/logs/stream`, {
+    headers: { Authorization: `Bearer ${BACKEND_API_TOKEN}` },
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response('Failed to connect to log stream', { status: 502 });
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Intercepts `process.stdout`/`process.stderr` in the backend to capture all app logs into an in-memory circular buffer (500 lines)
- Exposes `GET /logs` (history) and `GET /logs/stream` (SSE) backend endpoints, protected by `ApiClientAuthGuard`
- Adds Next.js API route `/api/logs/stream` that proxies the SSE stream from backend, with admin-only JWT check
- Adds `/admin/logs` page (admin-protected via `withUser(Page, true)`) with a mobile-friendly dark-theme live log viewer

## How to use

Open `https://beznomera.net/admin/logs` on your phone (requires admin account). Logs stream in real time with color coding by level. Tap **Pause** to freeze the view.

## Test plan

- [ ] Start backend, open `/admin/logs` — should see startup logs
- [ ] Trigger some backend actions (login, etc.) — new log lines appear in real time
- [ ] Non-admin user accessing `/admin/logs` redirects to `/auth`
- [ ] `/api/logs/stream` without auth returns 401

https://claude.ai/code/session_01MnaqgvSERoz29uFPAsVpVb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnaqgvSERoz29uFPAsVpVb)_