### PR TITLE
feat(notifications): клик по уведомлению «вызов» открывает чат

### DIFF
--- a/packages/backend/src/app/car/car.service.ts
+++ b/packages/backend/src/app/car/car.service.ts
@@ -216,6 +216,7 @@ export class CarService {
       carId: id,
       carCode: car.code,
       carNo: no,
+      chatId: callResult?.message?.chatId,
       title: 'Вас вызвали',
       body: `Водителя вызвали к автомобилю ${no}`,
     } satisfies CarNotificationEvent);

--- a/packages/backend/src/app/notification/notification.service.ts
+++ b/packages/backend/src/app/notification/notification.service.ts
@@ -77,6 +77,7 @@ export class NotificationService {
       type: event.type,
       carId: event.carId,
       carCode: event.carCode,
+      chatId: event.chatId,
       title: event.title,
       body: event.body,
     });

--- a/packages/shared/src/notification/notification.types.ts
+++ b/packages/shared/src/notification/notification.types.ts
@@ -18,6 +18,7 @@ export interface CarNotificationEvent {
   carId: number;
   carCode: string;
   carNo: string;
+  chatId?: number;
   title: string;
   body: string;
 }

--- a/packages/web/public/service-worker.js
+++ b/packages/web/public/service-worker.js
@@ -51,9 +51,11 @@ self.addEventListener('notificationclick', function (event) {
       ? `/messages/${chatId}`
       : type === 'message' && carCode
         ? `/g/${carCode}/chat`
-        : type === 'call' && carId
-          ? `/car/${carId}`
-          : '/';
+        : type === 'call' && chatId
+          ? `/messages/${chatId}`
+          : type === 'call' && carCode
+            ? `/g/${carCode}/chat`
+            : '/';
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (list) {


### PR DESCRIPTION
## Summary

- Добавлен `chatId` в `CarNotificationEvent` (shared types)
- `chatId` из `callResult` передаётся в событие `car.call` (car.service.ts)
- `chatId` включается в push payload для уведомления типа `call` (notification.service.ts)
- Service worker: клик по уведомлению `call` теперь открывает `/messages/:chatId` вместо `/car/:carId`; если по какой-то причине `chatId` нет — fallback на `/g/:carCode/chat`

## Test plan

- [ ] Создать чат через QR-код, затем нажать «Вызвать водителя»
- [ ] Дождаться push-уведомления на устройстве водителя/владельца
- [ ] Тапнуть по уведомлению — должен открыться чат (`/messages/:chatId`), а не страница авто

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MhvUVz3zmnToUdPq4yFYs

---
_Generated by [Claude Code](https://claude.ai/code/session_012MhvUVz3zmnToUdPq4yFYs)_